### PR TITLE
Add metadata server mongo backend

### DIFF
--- a/authorization/authorization.go
+++ b/authorization/authorization.go
@@ -149,7 +149,7 @@ func (authorizer *Authorizer) GetRespondAuthChallengeHandler(userIDString string
 		err = rsa.VerifyPKCS1v15(publicKey.(*rsa.PublicKey), crypto.SHA256, decodedNonce[:], decoded)
 		if err != nil {
 			w.WriteHeader(http.StatusUnauthorized)
-			resp := AuthChallengeError{Error: "key verification failed"}
+			resp := AuthChallengeError{Error: err.Error()}
 			json.NewEncoder(w).Encode(resp)
 		} else {
 			token := jwt.New(jwt.SigningMethodHS256)

--- a/authorization/authorization.go
+++ b/authorization/authorization.go
@@ -111,6 +111,8 @@ func (authorizer *Authorizer) GetRespondAuthChallengeHandler(userIDString string
 		if err != nil {
 			authorizer.logger.Println(err)
 			w.WriteHeader(http.StatusUnauthorized)
+			resp := AuthChallengeError{Error: "could not find user's public key"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
@@ -118,6 +120,8 @@ func (authorizer *Authorizer) GetRespondAuthChallengeHandler(userIDString string
 		if block == nil {
 			authorizer.logger.Println("Could not decode PEM.")
 			w.WriteHeader(http.StatusUnauthorized)
+			resp := AuthChallengeError{Error: "could not decode user's public key"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
@@ -125,6 +129,8 @@ func (authorizer *Authorizer) GetRespondAuthChallengeHandler(userIDString string
 		if err != nil {
 			authorizer.logger.Println("Could not parse public key for user.")
 			w.WriteHeader(http.StatusUnauthorized)
+			resp := AuthChallengeError{Error: "could not parse user's public key"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
@@ -143,6 +149,8 @@ func (authorizer *Authorizer) GetRespondAuthChallengeHandler(userIDString string
 		if err != nil {
 			authorizer.logger.Println("Could not decode stored nonce.")
 			w.WriteHeader(http.StatusInternalServerError)
+			resp := AuthChallengeError{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 

--- a/authorization/client.go
+++ b/authorization/client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -56,7 +57,6 @@ func (client *Client) GetAuthToken(privateKey *rsa.PrivateKey, authType string, 
 	if err != nil {
 		return "", err
 	} else {
-		println(resp.StatusCode)
 		var b []byte
 		defer resp.Body.Close()
 		b, err := ioutil.ReadAll(resp.Body)
@@ -64,8 +64,7 @@ func (client *Client) GetAuthToken(privateKey *rsa.PrivateKey, authType string, 
 			return "", err
 		}
 		if resp.StatusCode != 200 {
-			println(string(b))
-			panic("Bad status: " + resp.Status)
+			return "", errors.New(string(b))
 		}
 		return string(b), nil
 	}

--- a/cmd/metaserver.go
+++ b/cmd/metaserver.go
@@ -38,5 +38,6 @@ func runMetaServer(args ...string) {
 	server := metaserver.InitServer(".", logger)
 
 	log.Println("starting metaserver server at", addr)
+	defer server.Close()
 	log.Fatal(http.ListenAndServe(addr, server))
 }

--- a/cmd/renter.go
+++ b/cmd/renter.go
@@ -2,16 +2,15 @@ package cmd
 
 import (
 	"flag"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"path"
-	"skybin/renter"
-	"skybin/metaserver"
 	"skybin/core"
+	"skybin/metaserver"
+	"skybin/renter"
 	"skybin/util"
-	"io/ioutil"
-	"fmt"
 )
 
 var renterCmd = Cmd{
@@ -42,7 +41,7 @@ func runRenter(args ...string) {
 			log.Fatal("Unable to read public key file. Error: ", err)
 		}
 		info := core.RenterInfo{
-			ID: r.Config.RenterId,
+			ID:        r.Config.RenterId,
 			PublicKey: string(pubKeyBytes),
 		}
 		metaService := metaserver.NewClient(r.Config.MetaAddr, &http.Client{})

--- a/core/core.go
+++ b/core/core.go
@@ -17,12 +17,9 @@ type ProviderInfo struct {
 }
 
 type RenterInfo struct {
-	ID         string       `json:"id"`
-	Alias      string       `json:"alias"`
-	PublicKey  string       `json:"publicKey"`
-	Contracts  []Contract   `json:"contracts"`
-	Files      []FileRecord `json:"files"`
-	SharedWith []FileRecord `json:"sharedWith"`
+	ID        string `json:"id"`
+	PublicKey string `json:"publicKey"`
+	Files     []File `json:"files"`
 }
 
 type Contract struct {
@@ -53,13 +50,12 @@ type Block struct {
 
 // Permission provides access to a file to a non-owning user
 type Permission struct {
+
 	// The user who this permission grants access to
 	UserId string `json:"userId"`
+
 	// The file's encryption key encrypted with the user's public key
-	EncryptionKey        string `json:"encryptionKey"`
-	InitializationVector string `json:"initializationVector"`
-	CanWrite             bool   `json:"canWrite"`
-	CanShare             bool   `json:"canShare"`
+	SessionKey string `json:"sessionKey"`
 }
 
 type File struct {
@@ -70,11 +66,5 @@ type File struct {
 	ModTime    time.Time    `json:"modTime"`
 	AccessList []Permission `json:"accessList"`
 	Blocks     []Block      `json:"blocks"`
-	VersionNum int          `json:"versionNum"`
 	OwnerID    string       `json:"ownerID"`
-}
-
-type FileRecord struct {
-	ID   string `json:"id"`
-	Path string `json:"path"`
 }

--- a/core/core.go
+++ b/core/core.go
@@ -17,9 +17,12 @@ type ProviderInfo struct {
 }
 
 type RenterInfo struct {
-	ID        string `json:"id"`
-	PublicKey string `json:"publicKey"`
-	Files     []File `json:"files"`
+	ID         string       `json:"id"`
+	Alias      string       `json:"alias"`
+	PublicKey  string       `json:"publicKey"`
+	Contracts  []Contract   `json:"contracts"`
+	Files      []FileRecord `json:"files"`
+	SharedWith []FileRecord `json:"sharedWith"`
 }
 
 type Contract struct {
@@ -50,12 +53,13 @@ type Block struct {
 
 // Permission provides access to a file to a non-owning user
 type Permission struct {
-
 	// The user who this permission grants access to
 	UserId string `json:"userId"`
-
 	// The file's encryption key encrypted with the user's public key
-	SessionKey string `json:"sessionKey"`
+	EncryptionKey        string `json:"encryptionKey"`
+	InitializationVector string `json:"initializationVector"`
+	CanWrite             bool   `json:"canWrite"`
+	CanShare             bool   `json:"canShare"`
 }
 
 type File struct {
@@ -66,5 +70,11 @@ type File struct {
 	ModTime    time.Time    `json:"modTime"`
 	AccessList []Permission `json:"accessList"`
 	Blocks     []Block      `json:"blocks"`
+	VersionNum int          `json:"versionNum"`
+	OwnerID    string       `json:"ownerID"`
 }
 
+type FileRecord struct {
+	ID   string `json:"id"`
+	Path string `json:"path"`
+}

--- a/core/core.go
+++ b/core/core.go
@@ -17,9 +17,27 @@ type ProviderInfo struct {
 }
 
 type RenterInfo struct {
-	ID        string `json:"id"`
-	PublicKey string `json:"publicKey"`
-	Files     []File `json:"files"`
+	ID        string   `json:"id"`
+	Alias     string   `json:"alias"`
+	PublicKey string   `json:"publicKey"`
+	Files     []string `json:"files"`
+	Shared    []string `json:"shared"`
+}
+
+type Version struct {
+	Number int     `json:"number"`
+	Blocks []Block `json:"blocks"`
+	Size       int64        `json:"size"`
+	ModTime    time.Time    `json:"modTime"`
+}
+
+type File struct {
+	Name       string       `json:"name"`
+	ID         string       `json:"id"`
+	IsDir      bool         `json:"isDir"`
+	AccessList []Permission `json:"accessList"`
+	Versions   []Version    `json:"versions"`
+	OwnerID    string       `json:"ownerID"`
 }
 
 type Contract struct {
@@ -56,15 +74,4 @@ type Permission struct {
 
 	// The file's encryption key encrypted with the user's public key
 	SessionKey string `json:"sessionKey"`
-}
-
-type File struct {
-	ID         string       `json:"id"`
-	Name       string       `json:"name"`
-	IsDir      bool         `json:"isDir"`
-	Size       int64        `json:"size"`
-	ModTime    time.Time    `json:"modTime"`
-	AccessList []Permission `json:"accessList"`
-	Blocks     []Block      `json:"blocks"`
-	OwnerID    string       `json:"ownerID"`
 }

--- a/core/core.go
+++ b/core/core.go
@@ -25,10 +25,10 @@ type RenterInfo struct {
 }
 
 type Version struct {
-	Number int     `json:"number"`
-	Blocks []Block `json:"blocks"`
-	Size       int64        `json:"size"`
-	ModTime    time.Time    `json:"modTime"`
+	Number  int       `json:"number"`
+	Blocks  []Block   `json:"blocks"`
+	Size    int64     `json:"size"`
+	ModTime time.Time `json:"modTime"`
 }
 
 type File struct {

--- a/integration/clear_db.js
+++ b/integration/clear_db.js
@@ -1,0 +1,3 @@
+const dbAddr = '127.0.0.1/skybin'
+var db = connect(dbAddr)
+db.dropDatabase()

--- a/integration/multi_upload_test.py
+++ b/integration/multi_upload_test.py
@@ -58,6 +58,7 @@ def main():
     args = parser.parse_args()
     ctxt = setup_test(
         num_providers=args.num_providers,
+        alias='multiFileUploadTest',
     )
     try:
         test_multi_upload(

--- a/integration/setup.sh
+++ b/integration/setup.sh
@@ -8,6 +8,8 @@ trap "kill 0" EXIT
 REPO_DIR="./repo"
 TEST_FILE_DIR="./files"
 
+RENTER_ALIAS="test"
+
 echo "building skybin"
 cd .. && go build
 cd -
@@ -29,6 +31,6 @@ echo "starting provider"
 ../skybin provider &
 
 echo "starting renter"
-../skybin renter &
+../skybin renter -alias test &
 
 wait

--- a/integration/setup_db.js
+++ b/integration/setup_db.js
@@ -1,7 +1,10 @@
 const dbAddr = '127.0.0.1/skybin'
 var db = connect(dbAddr)
 
-db.renters.createIndex({"alias": 1, "ID": 1}, {unique: true})
-db.providers.createIndex({"ID": 1}, {unique: true})
-db.files.createIndex({"ID": 1}, {unique: true})
-db.files.createIndex({"name": 1, "ownerID": 1}, {unique: true})
+db.renters.createIndex({"id": 1}, {unique: true})
+db.renters.createIndex({"alias": 1}, {unique: true})
+
+db.providers.createIndex({"id": 1}, {unique: true})
+
+db.files.createIndex({"id": 1}, {unique: true})
+db.files.createIndex({"name": 1, "ownerid": 1}, {unique: true})

--- a/integration/setup_db.js
+++ b/integration/setup_db.js
@@ -8,3 +8,5 @@ db.providers.createIndex({"id": 1}, {unique: true})
 
 db.files.createIndex({"id": 1}, {unique: true})
 db.files.createIndex({"name": 1, "ownerid": 1}, {unique: true})
+
+db.contracts.createIndex({"id": 1}, {unique: true})

--- a/integration/setup_db.js
+++ b/integration/setup_db.js
@@ -1,0 +1,7 @@
+const dbAddr = '127.0.0.1/skybin'
+var db = connect(dbAddr)
+
+db.renters.createIndex({"alias": 1, "ID": 1}, {unique: true})
+db.providers.createIndex({"ID": 1}, {unique: true})
+db.files.createIndex({"ID": 1}, {unique: true})
+db.files.createIndex({"name": 1, "ownerID": 1}, {unique: true})

--- a/integration/single_upload_test.py
+++ b/integration/single_upload_test.py
@@ -32,6 +32,7 @@ def main():
     args = parser.parse_args()
     ctxt = setup_test(
         num_providers=args.num_providers,
+        alias='singleFileUploadTest'
     )
     try:
         test_single_upload(ctxt, file_size=args.file_size)

--- a/integration/test_framework.py
+++ b/integration/test_framework.py
@@ -207,7 +207,7 @@ def create_metaserver():
     check_service_startup(process)
     return Service(process=process, address=address)
 
-def create_renter(metaserver_addr, repo_dir):
+def create_renter(metaserver_addr, repo_dir, alias):
     """Create and start a new renter instance."""
 
     # Create repo
@@ -225,7 +225,7 @@ def create_renter(metaserver_addr, repo_dir):
     # Start renter server
     env = os.environ.copy()
     env['SKYBIN_HOME'] = homedir
-    args = [SKYBIN_CMD, 'renter']
+    args = [SKYBIN_CMD, 'renter', '-alias', alias]
     process = subprocess.Popen(args, env=env, stderr=subprocess.PIPE)
 
     check_service_startup(process)
@@ -259,7 +259,8 @@ def setup_test(num_providers=1,
                repo_dir=DEFAULT_REPOS_DIR,
                test_file_dir=DEFAULT_TEST_FILE_DIR,
                log_enabled=LOG_ENABLED,
-               remove_test_files=REMOVE_TEST_FILES):
+               remove_test_files=REMOVE_TEST_FILES,
+               alias='test'):
     """Create a test context.
 
     Args:
@@ -281,7 +282,7 @@ def setup_test(num_providers=1,
         for _ in range(num_providers):
             pvdr = create_provider(ctxt.metaserver.address, repo_dir=repo_dir)
             ctxt.providers.append(pvdr)
-        ctxt.renter = create_renter(ctxt.metaserver.address, repo_dir=repo_dir)
+        ctxt.renter = create_renter(ctxt.metaserver.address, repo_dir=repo_dir, alias=alias)
     except Exception as err:
         ctxt.teardown()
         raise err

--- a/metaserver/client.go
+++ b/metaserver/client.go
@@ -24,9 +24,19 @@ type Client struct {
 	token  string
 }
 
-func (client *Client) Authorize(privateKey *rsa.PrivateKey, renterID string) error {
+func (client *Client) AuthorizeRenter(privateKey *rsa.PrivateKey, renterID string) error {
 	authClient := authorization.NewClient(client.addr, client.client)
 	token, err := authClient.GetAuthToken(privateKey, "renter", renterID)
+	if err != nil {
+		return err
+	}
+	client.token = token
+	return nil
+}
+
+func (client *Client) AuthorizeProvider(privateKey *rsa.PrivateKey, providerID string) error {
+	authClient := authorization.NewClient(client.addr, client.client)
+	token, err := authClient.GetAuthToken(privateKey, "provider", providerID)
 	if err != nil {
 		return err
 	}

--- a/metaserver/client.go
+++ b/metaserver/client.go
@@ -116,37 +116,37 @@ func (client *Client) RegisterRenter(info *core.RenterInfo) error {
 	return nil
 }
 
-func (client *Client) GetRenter(renterID string) (core.RenterInfo, error) {
+func (client *Client) GetRenter(renterID string) (*core.RenterInfo, error) {
 	if client.token == "" {
-		return core.RenterInfo{}, errors.New("must authorize before calling this method")
+		return nil, errors.New("must authorize before calling this method")
 	}
 
 	url := fmt.Sprintf("http://%s/renters/%s", client.addr, renterID)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return core.RenterInfo{}, err
+		return nil, err
 	}
 
 	token := fmt.Sprintf("Bearer %s", client.token)
 	req.Header.Add("Authorization", token)
 
 	resp, err := client.client.Do(req)
-	if resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusOK {
 		var respMsg postRenterResp
 		err = json.NewDecoder(resp.Body).Decode(&respMsg)
 		if err != nil {
-			return core.RenterInfo{}, err
+			return nil, err
 		}
-		return core.RenterInfo{}, errors.New(respMsg.Error)
+		return nil, errors.New(respMsg.Error)
 	}
 
 	var renter core.RenterInfo
 	err = json.NewDecoder(resp.Body).Decode(&renter)
 	if err != nil {
-		return core.RenterInfo{}, err
+		return nil, err
 	}
-	return renter, nil
+	return &renter, nil
 }
 
 func (client *Client) PostFile(file core.File) error {

--- a/metaserver/client.go
+++ b/metaserver/client.go
@@ -182,6 +182,34 @@ func (client *Client) UpdateRenter(renter *core.RenterInfo) error {
 	return nil
 }
 
+func (client *Client) DeleteRenter(renterID string) error {
+	if client.token == "" {
+		return errors.New("must authorize before calling this method")
+	}
+
+	url := fmt.Sprintf("http://%s/renters/%s", client.addr, renterID)
+
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if resp.StatusCode != http.StatusOK {
+		var respMsg postRenterResp
+		err = json.NewDecoder(resp.Body).Decode(&respMsg)
+		if err != nil {
+			return err
+		}
+		return errors.New(respMsg.Error)
+	}
+
+	return nil
+}
+
 func (client *Client) PostFile(file core.File) error {
 	if client.token == "" {
 		return errors.New("must authorize before calling this method")

--- a/metaserver/client.go
+++ b/metaserver/client.go
@@ -258,7 +258,7 @@ func (client *Client) DeleteRenter(renterID string) error {
 	return nil
 }
 
-func (client *Client) PostFile(renterID string, file core.File) error {
+func (client *Client) PostFile(renterID string, file *core.File) error {
 	if client.token == "" {
 		return errors.New("must authorize before calling this method")
 	}
@@ -290,7 +290,7 @@ func (client *Client) PostFile(renterID string, file core.File) error {
 	return nil
 }
 
-func (client *Client) UpdateFile(renterID string, file core.File) error {
+func (client *Client) UpdateFile(renterID string, file *core.File) error {
 	if client.token == "" {
 		return errors.New("must authorize before calling this method")
 	}
@@ -412,7 +412,7 @@ func (client *Client) DeleteFile(renterID string, fileID string) error {
 	return nil
 }
 
-func (client *Client) PostFileVersion(renterID string, fileID string, version core.Version) error {
+func (client *Client) PostFileVersion(renterID string, fileID string, version *core.Version) error {
 	if client.token == "" {
 		return errors.New("must authorize before calling this method")
 	}
@@ -444,7 +444,7 @@ func (client *Client) PostFileVersion(renterID string, fileID string, version co
 	return nil
 }
 
-func (client *Client) PutFileVersion(renterID string, fileID string, version core.Version) error {
+func (client *Client) PutFileVersion(renterID string, fileID string, version *core.Version) error {
 	if client.token == "" {
 		return errors.New("must authorize before calling this method")
 	}
@@ -600,7 +600,7 @@ func (client *Client) GetSharedFile(renterID string, fileID string) (*core.File,
 	return &file, nil
 }
 
-func (client *Client) ShareFile(renterID string, fileID string, permission core.Permission) error {
+func (client *Client) ShareFile(renterID string, fileID string, permission *core.Permission) error {
 	if client.token == "" {
 		return errors.New("must authorize before calling this method")
 	}
@@ -717,7 +717,7 @@ func (client *Client) RemoveSharedFile(renterID string, fileID string) error {
 	return nil
 }
 
-func (client *Client) PostContract(renterID string, contract core.Contract) error {
+func (client *Client) PostContract(renterID string, contract *core.Contract) error {
 	if client.token == "" {
 		return errors.New("must authorize before calling this method")
 	}

--- a/metaserver/client.go
+++ b/metaserver/client.go
@@ -308,12 +308,7 @@ func (client *Client) PostFile(renterID string, file core.File) error {
 	}
 
 	if resp.StatusCode != http.StatusCreated {
-		var respMsg fileResp
-		err = json.NewDecoder(resp.Body).Decode(&respMsg)
-		if err != nil {
-			return errors.New(resp.Status)
-		}
-		return errors.New(respMsg.Error)
+		return errors.New(resp.Status)
 	}
 
 	return nil
@@ -449,12 +444,12 @@ func (client *Client) GetFiles(renterID string) ([]core.File, error) {
 	return files, nil
 }
 
-func (client *Client) DeleteFile(fileID string) error {
+func (client *Client) DeleteFile(renterID string, fileID string) error {
 	if client.token == "" {
 		return errors.New("must authorize before calling this method")
 	}
 
-	url := fmt.Sprintf("http://%s/files/%s", client.addr, fileID)
+	url := fmt.Sprintf("http://%s/renters/%s/files/%s", client.addr, renterID, fileID)
 
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
@@ -467,6 +462,9 @@ func (client *Client) DeleteFile(fileID string) error {
 	resp, err := client.client.Do(req)
 	if err != nil {
 		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.New(resp.Status)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/metaserver/client.go
+++ b/metaserver/client.go
@@ -105,6 +105,68 @@ func (client *Client) GetProvider(providerID string) (core.ProviderInfo, error) 
 	return respMsg, nil
 }
 
+func (client *Client) UpdateProvider(provider *core.ProviderInfo) error {
+	if client.token == "" {
+		return errors.New("must authorize before calling this method")
+	}
+
+	url := fmt.Sprintf("http://%s/providers/%s", client.addr, provider.ID)
+
+	b, err := json.Marshal(provider)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("PUT", url, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if resp.StatusCode != http.StatusOK {
+		var respMsg postProviderResp
+		err = json.NewDecoder(resp.Body).Decode(&respMsg)
+		if err != nil {
+			return err
+		}
+		return errors.New(respMsg.Error)
+	}
+
+	return nil
+}
+
+func (client *Client) DeleteProvider(providerID string) error {
+	if client.token == "" {
+		return errors.New("must authorize before calling this method")
+	}
+
+	url := fmt.Sprintf("http://%s/providers/%s", client.addr, providerID)
+
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if resp.StatusCode != http.StatusOK {
+		println(resp.Status)
+		var respMsg postRenterResp
+		err = json.NewDecoder(resp.Body).Decode(&respMsg)
+		if err != nil {
+			return err
+		}
+		return errors.New(respMsg.Error)
+	}
+
+	return nil
+}
+
 func (client *Client) RegisterRenter(info *core.RenterInfo) error {
 	url := fmt.Sprintf("http://%s/renters", client.addr)
 	body, err := json.Marshal(info)

--- a/metaserver/client.go
+++ b/metaserver/client.go
@@ -9,30 +9,18 @@ import (
 	"skybin/core"
 )
 
-func NewClient(addr string, client *http.Client) *Client {
+func NewClient(addr string, authToken string, client *http.Client) *Client {
 	return &Client{
 		addr:   addr,
 		client: client,
+		token:  authToken,
 	}
 }
 
 type Client struct {
 	addr   string
 	client *http.Client
-}
-
-func (client *Client) GetProviders() ([]core.ProviderInfo, error) {
-	url := fmt.Sprintf("http://%s/providers", client.addr)
-	resp, err := client.client.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	var respMsg getProvidersResp
-	_ = json.NewDecoder(resp.Body).Decode(&respMsg)
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New(respMsg.Error)
-	}
-	return respMsg.Providers, nil
+	token  string
 }
 
 func (client *Client) RegisterProvider(info *core.ProviderInfo) error {
@@ -56,7 +44,216 @@ func (client *Client) RegisterProvider(info *core.ProviderInfo) error {
 	return nil
 }
 
+func (client *Client) GetProviders() ([]core.ProviderInfo, error) {
+	url := fmt.Sprintf("http://%s/providers", client.addr)
+
+	resp, err := client.client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var respMsg getProvidersResp
+	err = json.NewDecoder(resp.Body).Decode(&respMsg)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(respMsg.Error)
+	}
+
+	return respMsg.Providers, nil
+}
+
+func (client *Client) GetProvider(providerID string) (core.ProviderInfo, error) {
+	url := fmt.Sprintf("http://%s/providers/%s", client.addr, providerID)
+
+	resp, err := client.client.Get(url)
+	if err != nil {
+		return core.ProviderInfo{}, err
+	}
+
+	var respMsg core.ProviderInfo
+	err = json.NewDecoder(resp.Body).Decode(&respMsg)
+	if err != nil {
+		return core.ProviderInfo{}, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return core.ProviderInfo{}, errors.New("bad status from server")
+	}
+
+	return respMsg, nil
+}
+
 func (client *Client) RegisterRenter(info *core.RenterInfo) error {
-	// TODO: implement
+	url := fmt.Sprintf("http://%s/renters", client.addr)
+	body, err := json.Marshal(info)
+	if err != nil {
+		return err
+	}
+	resp, err := client.client.Post(url, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusCreated {
+		var respMsg postRenterResp
+		err = json.NewDecoder(resp.Body).Decode(&respMsg)
+		if err != nil {
+			return err
+		}
+		return errors.New(respMsg.Error)
+	}
+	return nil
+}
+
+func (client *Client) GetRenter(renterID string) (core.RenterInfo, error) {
+	url := fmt.Sprintf("http://%s/renters/%s", client.addr, renterID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return core.RenterInfo{}, err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if resp.StatusCode != http.StatusCreated {
+		var respMsg postRenterResp
+		err = json.NewDecoder(resp.Body).Decode(&respMsg)
+		if err != nil {
+			return core.RenterInfo{}, err
+		}
+		return core.RenterInfo{}, errors.New(respMsg.Error)
+	}
+
+	var renter core.RenterInfo
+	err = json.NewDecoder(resp.Body).Decode(&renter)
+	if err != nil {
+		return core.RenterInfo{}, err
+	}
+	return renter, nil
+}
+
+func (client *Client) PostFile(file core.File) error {
+	url := fmt.Sprintf("http://%s/files", client.addr)
+
+	var buf []byte
+	serialized := bytes.NewBuffer(buf)
+	_ = json.NewEncoder(serialized).Encode(file)
+	body := bytes.NewReader(buf)
+
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return errors.New("bad status from server")
+	}
+
+	return nil
+}
+
+func (client *Client) GetFile(fileID string) (core.File, error) {
+	url := fmt.Sprintf("http://%s/files/%s", client.addr, fileID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return core.File{}, err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if err != nil {
+		return core.File{}, err
+	}
+
+	var file core.File
+	err = json.NewDecoder(resp.Body).Decode(&file)
+	if err != nil {
+		return core.File{}, err
+	}
+
+	return file, nil
+}
+
+func (client *Client) GetFileVersion(fileID string, fileVersion int) (core.File, error) {
+	url := fmt.Sprintf("http://%s/files/%s/%d", client.addr, fileID, fileVersion)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return core.File{}, err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if err != nil {
+		return core.File{}, err
+	}
+
+	var file core.File
+	err = json.NewDecoder(resp.Body).Decode(&file)
+	if err != nil {
+		return core.File{}, err
+	}
+
+	return file, nil
+}
+
+func (client *Client) DeleteFile(fileID string) error {
+	url := fmt.Sprintf("http://%s/files/%s", client.addr, fileID)
+
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("Bad response from server")
+	}
+
+	return nil
+}
+
+func (client *Client) DeleteFileVersion(fileID string, fileVersion int) error {
+	url := fmt.Sprintf("http://%s/files/%s/%d", client.addr, fileID, fileVersion)
+
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("Bad response from server")
+	}
+
 	return nil
 }

--- a/metaserver/client.go
+++ b/metaserver/client.go
@@ -149,6 +149,39 @@ func (client *Client) GetRenter(renterID string) (*core.RenterInfo, error) {
 	return &renter, nil
 }
 
+func (client *Client) UpdateRenter(renter *core.RenterInfo) error {
+	if client.token == "" {
+		return errors.New("must authorize before calling this method")
+	}
+
+	url := fmt.Sprintf("http://%s/renters/%s", client.addr, renter.ID)
+
+	b, err := json.Marshal(renter)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("PUT", url, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if resp.StatusCode != http.StatusOK {
+		var respMsg postRenterResp
+		err = json.NewDecoder(resp.Body).Decode(&respMsg)
+		if err != nil {
+			return err
+		}
+		return errors.New(respMsg.Error)
+	}
+
+	return nil
+}
+
 func (client *Client) PostFile(file core.File) error {
 	if client.token == "" {
 		return errors.New("must authorize before calling this method")

--- a/metaserver/client.go
+++ b/metaserver/client.go
@@ -417,6 +417,38 @@ func (client *Client) GetFileVersion(fileID string, fileVersion int) (core.File,
 	return file, nil
 }
 
+func (client *Client) GetFiles(renterID string) ([]core.File, error) {
+	if client.token == "" {
+		return nil, errors.New("must authorize before calling this method")
+	}
+
+	url := fmt.Sprintf("http://%s/renters/%s/files", client.addr, renterID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(resp.Status)
+	}
+
+	var files []core.File
+	err = json.NewDecoder(resp.Body).Decode(&files)
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
 func (client *Client) DeleteFile(fileID string) error {
 	if client.token == "" {
 		return errors.New("must authorize before calling this method")

--- a/metaserver/client.go
+++ b/metaserver/client.go
@@ -755,3 +755,135 @@ func (client *Client) RemoveSharedFile(renterID string, fileID string) error {
 
 	return nil
 }
+
+func (client *Client) PostContract(renterID string, contract core.Contract) error {
+	if client.token == "" {
+		return errors.New("must authorize before calling this method")
+	}
+
+	url := fmt.Sprintf("http://%s/renters/%s/contracts", client.addr, renterID)
+
+	b, err := json.Marshal(contract)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return errors.New(resp.Status)
+	}
+
+	return nil
+}
+
+func (client *Client) GetContract(renterID string, contractID string) (*core.Contract, error) {
+	if client.token == "" {
+		return nil, errors.New("must authorize before calling this method")
+	}
+
+	url := fmt.Sprintf("http://%s/renters/%s/contracts/%s", client.addr, renterID, contractID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(resp.Status)
+	}
+
+	var contract core.Contract
+	err = json.NewDecoder(resp.Body).Decode(&contract)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(resp.Status)
+	}
+
+	return &contract, nil
+}
+
+func (client *Client) GetRenterContracts(renterID string) ([]core.Contract, error) {
+	if client.token == "" {
+		return nil, errors.New("must authorize before calling this method")
+	}
+
+	url := fmt.Sprintf("http://%s/renters/%s/contracts", client.addr, renterID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(resp.Status)
+	}
+
+	var contracts []core.Contract
+	err = json.NewDecoder(resp.Body).Decode(&contracts)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(resp.Status)
+	}
+
+	return contracts, nil
+}
+
+func (client *Client) DeleteContract(renterID string, contractID string) error {
+	if client.token == "" {
+		return errors.New("must authorize before calling this method")
+	}
+
+	url := fmt.Sprintf("http://%s/renters/%s/contracts/%s", client.addr, renterID, contractID)
+
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+
+	token := fmt.Sprintf("Bearer %s", client.token)
+	req.Header.Add("Authorization", token)
+
+	resp, err := client.client.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.New(resp.Status)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("Bad response from server")
+	}
+
+	return nil
+}

--- a/metaserver/contracts.go
+++ b/metaserver/contracts.go
@@ -13,7 +13,7 @@ type contractResp struct {
 	Error    string        `json:"error,omitempty"`
 }
 
-func (server *metaServer) getContractsHandler() http.HandlerFunc {
+func (server *MetaServer) getContractsHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		// Make sure the specified renter actually exists.
@@ -37,7 +37,7 @@ func (server *metaServer) getContractsHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) postContractHandler() http.HandlerFunc {
+func (server *MetaServer) postContractHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var contract core.Contract
 		err := json.NewDecoder(r.Body).Decode(&contract)
@@ -75,7 +75,7 @@ func (server *metaServer) postContractHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) getContractHandler() http.HandlerFunc {
+func (server *MetaServer) getContractHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		contract, err := server.db.FindContractByID(params["contractID"])
@@ -89,7 +89,7 @@ func (server *metaServer) getContractHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) putContractHandler() http.HandlerFunc {
+func (server *MetaServer) putContractHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 
@@ -120,7 +120,7 @@ func (server *metaServer) putContractHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) deleteContractHandler() http.HandlerFunc {
+func (server *MetaServer) deleteContractHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		err := server.db.DeleteContract(params["contractID"])

--- a/metaserver/contracts.go
+++ b/metaserver/contracts.go
@@ -29,6 +29,8 @@ func (server *metaServer) getContractsHandler() http.HandlerFunc {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
+			resp := errorResp{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 		json.NewEncoder(w).Encode(contracts)
@@ -79,7 +81,8 @@ func (server *metaServer) getContractHandler() http.HandlerFunc {
 		contract, err := server.db.FindContractByID(params["contractID"])
 		if err != nil {
 			w.WriteHeader(http.StatusNotFound)
-			server.logger.Println(err)
+			resp := errorResp{Error: "could not find contract"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 		json.NewEncoder(w).Encode(contract)

--- a/metaserver/contracts.go
+++ b/metaserver/contracts.go
@@ -62,7 +62,7 @@ func (server *metaServer) postContractHandler() http.HandlerFunc {
 		// BUG(kincaid): Make sure the contract's renter ID is set to that of the renter.
 
 		// BUG(kincaid): DB will throw error if file already exists. Might want to check explicitly.
-		err = server.db.InsertContract(contract)
+		err = server.db.InsertContract(&contract)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			resp := contractResp{Error: err.Error()}
@@ -109,7 +109,7 @@ func (server *metaServer) putContractHandler() http.HandlerFunc {
 			return
 		}
 
-		err = server.db.UpdateContract(contract)
+		err = server.db.UpdateContract(&contract)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			resp := contractResp{Error: err.Error()}

--- a/metaserver/contracts.go
+++ b/metaserver/contracts.go
@@ -1,0 +1,132 @@
+package metaserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"skybin/core"
+
+	"github.com/gorilla/mux"
+)
+
+type contractResp struct {
+	Contract core.Contract `json:"file,omitempty"`
+	Error    string        `json:"error,omitempty"`
+}
+
+func (server *metaServer) getContractsHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		// Make sure the specified renter actually exists.
+		renter, err := server.db.FindRenterByID(params["renterID"])
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			resp := contractResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		// Retrieve the renter's contracts.
+		contracts, err := server.db.FindContractsByRenter(renter.ID)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			server.logger.Println(err)
+			return
+		}
+		json.NewEncoder(w).Encode(contracts)
+	})
+}
+
+func (server *metaServer) postContractHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var contract core.Contract
+		err := json.NewDecoder(r.Body).Decode(&contract)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := contractResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		params := mux.Vars(r)
+
+		// Make sure the renter exists.
+		_, err = server.db.FindRenterByID(params["renterID"])
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := contractResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		// BUG(kincaid): Make sure the contract's renter ID is set to that of the renter.
+
+		// BUG(kincaid): DB will throw error if file already exists. Might want to check explicitly.
+		err = server.db.InsertContract(contract)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := contractResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(contract)
+	})
+}
+
+func (server *metaServer) getContractHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		contract, err := server.db.FindContractByID(params["contractID"])
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			server.logger.Println(err)
+			return
+		}
+		json.NewEncoder(w).Encode(contract)
+	})
+}
+
+func (server *metaServer) putContractHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+
+		var contract core.Contract
+		err := json.NewDecoder(r.Body).Decode(&contract)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := contractResp{Error: "could not parse payload"}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if contract.ID != params["contractID"] {
+			w.WriteHeader(http.StatusUnauthorized)
+			resp := contractResp{Error: "must not change contact ID"}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		err = server.db.UpdateContract(contract)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := contractResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func (server *metaServer) deleteContractHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		err := server.db.DeleteContract(params["contractID"])
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := fileResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/metaserver/db.go
+++ b/metaserver/db.go
@@ -2,21 +2,52 @@ package metaserver
 
 import (
 	"skybin/core"
+	"time"
 )
 
-//
+// DB internal representation of core data structures
+//===================================================
+
+type RenterInfo struct {
+	ID        string       `json:"id"`
+	PublicKey string       `json:"publicKey"`
+	Files     []FileRecord `json:"files"`
+	Shared    []FileRecord `json:"shared"`
+}
+
+type Version struct {
+	ID     string       `json:"id"`
+	Blocks []core.Block `json:"blocks"`
+}
+
+type File struct {
+	ID         string            `json:"id"`
+	IsDir      bool              `json:"isDir"`
+	Size       int64             `json:"size"`
+	ModTime    time.Time         `json:"modTime"`
+	AccessList []core.Permission `json:"accessList"`
+	Versions   []Version         `json:"versions"`
+	OwnerID    string            `json:"ownerID"`
+}
+
+type FileRecord struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Interface containing operations that must be implemented for every database backend.
 type metaDB interface {
 	// Renter Operations
 	//==================
 
 	// Return a list of all renters in the database
-	FindAllRenters() []core.RenterInfo
+	FindAllRenters() ([]RenterInfo, error)
 	// Return the renter with the specified ID.
-	FindRenterByID(renterID string) (core.RenterInfo, error)
+	FindRenterByID(renterID string) (*RenterInfo, error)
 	// Insert the provided renter into the database.
-	InsertRenter(renter core.RenterInfo) error
+	InsertRenter(renter RenterInfo) error
 	// Update the provided renter in the databse.
-	UpdateRenter(renter core.RenterInfo) error
+	UpdateRenter(renter RenterInfo) error
 	// Delete the specified renter from the database.
 	DeleteRenter(renterID string) error
 
@@ -24,9 +55,9 @@ type metaDB interface {
 	//====================
 
 	// Return a list of all the providers in the database.
-	FindAllProviders() []core.ProviderInfo
+	FindAllProviders() ([]core.ProviderInfo, error)
 	// Return the provider with the specified ID.
-	FindProviderByID(providerID string) (core.ProviderInfo, error)
+	FindProviderByID(providerID string) (*core.ProviderInfo, error)
 	// Insert the given provider into the database.
 	InsertProvider(provider core.ProviderInfo) error
 	// Update the given provider in the databse.
@@ -38,17 +69,15 @@ type metaDB interface {
 	//====================
 
 	// Return a list of all files in the database.
-	FindAllFiles() []core.File
+	FindAllFiles() ([]File, error)
 	// Return the latest version of the file with the specified ID.
-	FindFileByID(fileID string) (core.File, error)
-	// Return the specified version of the file with the given ID.
-	FindFileByIDAndVersion(fileID string, version int) (core.File, error)
+	FindFileByID(fileID string) (*File, error)
+	// Return a list of files present in the renter's directory.
+	FindFilesByRenter(renterID string) ([]File, error)
 	// Insert the given file into the database.
-	InsertFile(file core.File) error
+	InsertFile(file File) error
 	// Update the given fiel in the database.
-	UpdateFile(file core.File) error
+	UpdateFile(file File) error
 	// Delete all versions of the given file from the database.
 	DeleteFile(fileID string) error
-	// Delete file with the given version and ID.
-	DeleteFileVersion(fileID string, version int) error
 }

--- a/metaserver/db.go
+++ b/metaserver/db.go
@@ -2,38 +2,7 @@ package metaserver
 
 import (
 	"skybin/core"
-	"time"
 )
-
-// DB internal representation of core data structures
-//===================================================
-
-type RenterInfo struct {
-	ID        string       `json:"id"`
-	PublicKey string       `json:"publicKey"`
-	Files     []FileRecord `json:"files"`
-	Shared    []FileRecord `json:"shared"`
-}
-
-type Version struct {
-	ID     string       `json:"id"`
-	Blocks []core.Block `json:"blocks"`
-}
-
-type File struct {
-	ID         string            `json:"id"`
-	IsDir      bool              `json:"isDir"`
-	Size       int64             `json:"size"`
-	ModTime    time.Time         `json:"modTime"`
-	AccessList []core.Permission `json:"accessList"`
-	Versions   []Version         `json:"versions"`
-	OwnerID    string            `json:"ownerID"`
-}
-
-type FileRecord struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-}
 
 // Interface containing operations that must be implemented for every database backend.
 type metaDB interface {
@@ -41,13 +10,13 @@ type metaDB interface {
 	//==================
 
 	// Return a list of all renters in the database
-	FindAllRenters() ([]RenterInfo, error)
+	FindAllRenters() ([]core.RenterInfo, error)
 	// Return the renter with the specified ID.
-	FindRenterByID(renterID string) (*RenterInfo, error)
+	FindRenterByID(renterID string) (*core.RenterInfo, error)
 	// Insert the provided renter into the database.
-	InsertRenter(renter RenterInfo) error
+	InsertRenter(renter core.RenterInfo) error
 	// Update the provided renter in the databse.
-	UpdateRenter(renter RenterInfo) error
+	UpdateRenter(renter core.RenterInfo) error
 	// Delete the specified renter from the database.
 	DeleteRenter(renterID string) error
 
@@ -69,15 +38,19 @@ type metaDB interface {
 	//====================
 
 	// Return a list of all files in the database.
-	FindAllFiles() ([]File, error)
+	FindAllFiles() ([]core.File, error)
 	// Return the latest version of the file with the specified ID.
-	FindFileByID(fileID string) (*File, error)
-	// Return a list of files present in the renter's directory.
-	FindFilesByRenter(renterID string) ([]File, error)
+	FindFileByID(fileID string) (*core.File, error)
+	// Return a map of paths to files present in the renter's directory.
+	FindFilesInRenterDirectory(renterID string) ([]core.File, error)
+	// Return a map of names to files shared with a given renter.
+	FindFilesSharedWithRenter(renterID string) ([]core.File, error)
+	// Return a list of files that the renter owns.
+	FindFilesByOwner(renterID string) ([]core.File, error)
 	// Insert the given file into the database.
-	InsertFile(file File) error
+	InsertFile(file core.File) error
 	// Update the given fiel in the database.
-	UpdateFile(file File) error
+	UpdateFile(file core.File) error
 	// Delete all versions of the given file from the database.
 	DeleteFile(fileID string) error
 }

--- a/metaserver/db.go
+++ b/metaserver/db.go
@@ -14,9 +14,9 @@ type metaDB interface {
 	// Return the renter with the specified ID.
 	FindRenterByID(renterID string) (*core.RenterInfo, error)
 	// Insert the provided renter into the database.
-	InsertRenter(renter core.RenterInfo) error
+	InsertRenter(renter *core.RenterInfo) error
 	// Update the provided renter in the databse.
-	UpdateRenter(renter core.RenterInfo) error
+	UpdateRenter(renter *core.RenterInfo) error
 	// Delete the specified renter from the database.
 	DeleteRenter(renterID string) error
 
@@ -28,9 +28,9 @@ type metaDB interface {
 	// Return the provider with the specified ID.
 	FindProviderByID(providerID string) (*core.ProviderInfo, error)
 	// Insert the given provider into the database.
-	InsertProvider(provider core.ProviderInfo) error
+	InsertProvider(provider *core.ProviderInfo) error
 	// Update the given provider in the databse.
-	UpdateProvider(provider core.ProviderInfo) error
+	UpdateProvider(provider *core.ProviderInfo) error
 	// Delete the specified provider from the dtabase.
 	DeleteProvider(providerID string) error
 
@@ -48,9 +48,9 @@ type metaDB interface {
 	// Return a list of files that the renter owns.
 	FindFilesByOwner(renterID string) ([]core.File, error)
 	// Insert the given file into the database.
-	InsertFile(file core.File) error
+	InsertFile(file *core.File) error
 	// Update the given file in the database.
-	UpdateFile(file core.File) error
+	UpdateFile(file *core.File) error
 	// Delete all versions of the given file from the database.
 	DeleteFile(fileID string) error
 
@@ -64,9 +64,9 @@ type metaDB interface {
 	// Return a list of contracts belonging to the specified renter.
 	FindContractsByRenter(renterID string) ([]core.Contract, error)
 	// Insert the given contract into the database.
-	InsertContract(contract core.Contract) error
+	InsertContract(contract *core.Contract) error
 	// Update the given contract.
-	UpdateContract(contract core.Contract) error
+	UpdateContract(contract *core.Contract) error
 	// Delete the contract.
 	DeleteContract(contractID string) error
 }

--- a/metaserver/db.go
+++ b/metaserver/db.go
@@ -6,6 +6,8 @@ import (
 
 // Interface containing operations that must be implemented for every database backend.
 type metaDB interface {
+	CloseDB()
+
 	// Renter Operations
 	//==================
 

--- a/metaserver/db.go
+++ b/metaserver/db.go
@@ -1,0 +1,54 @@
+package metaserver
+
+import (
+	"skybin/core"
+)
+
+//
+type metaDB interface {
+	// Renter Operations
+	//==================
+
+	// Return a list of all renters in the database
+	FindAllRenters() []core.RenterInfo
+	// Return the renter with the specified ID.
+	FindRenterByID(renterID string) (core.RenterInfo, error)
+	// Insert the provided renter into the database.
+	InsertRenter(renter core.RenterInfo) error
+	// Update the provided renter in the databse.
+	UpdateRenter(renter core.RenterInfo) error
+	// Delete the specified renter from the database.
+	DeleteRenter(renterID string) error
+
+	// Provider operations
+	//====================
+
+	// Return a list of all the providers in the database.
+	FindAllProviders() []core.ProviderInfo
+	// Return the provider with the specified ID.
+	FindProviderByID(providerID string) (core.ProviderInfo, error)
+	// Insert the given provider into the database.
+	InsertProvider(provider core.ProviderInfo) error
+	// Update the given provider in the databse.
+	UpdateProvider(provider core.ProviderInfo) error
+	// Delete the specified provider from the dtabase.
+	DeleteProvider(providerID string) error
+
+	// File operations
+	//====================
+
+	// Return a list of all files in the database.
+	FindAllFiles() []core.File
+	// Return the latest version of the file with the specified ID.
+	FindFileByID(fileID string) (core.File, error)
+	// Return the specified version of the file with the given ID.
+	FindFileByIDAndVersion(fileID string, version int) (core.File, error)
+	// Insert the given file into the database.
+	InsertFile(file core.File) error
+	// Update the given fiel in the database.
+	UpdateFile(file core.File) error
+	// Delete all versions of the given file from the database.
+	DeleteFile(fileID string) error
+	// Delete file with the given version and ID.
+	DeleteFileVersion(fileID string, version int) error
+}

--- a/metaserver/db.go
+++ b/metaserver/db.go
@@ -41,7 +41,7 @@ type metaDB interface {
 	FindAllFiles() ([]core.File, error)
 	// Return the latest version of the file with the specified ID.
 	FindFileByID(fileID string) (*core.File, error)
-	// Return a map of paths to files present in the renter's directory.
+	// Return a list of files present in the renter's directory.
 	FindFilesInRenterDirectory(renterID string) ([]core.File, error)
 	// Return a map of names to files shared with a given renter.
 	FindFilesSharedWithRenter(renterID string) ([]core.File, error)
@@ -49,8 +49,24 @@ type metaDB interface {
 	FindFilesByOwner(renterID string) ([]core.File, error)
 	// Insert the given file into the database.
 	InsertFile(file core.File) error
-	// Update the given fiel in the database.
+	// Update the given file in the database.
 	UpdateFile(file core.File) error
 	// Delete all versions of the given file from the database.
 	DeleteFile(fileID string) error
+
+	// Contract operations
+	//=====================
+
+	// Return a list of all contracts in the database.
+	FindAllContracts() ([]core.Contract, error)
+	// Return the contract with the specified ID
+	FindContractByID(contractID string) (*core.Contract, error)
+	// Return a list of contracts belonging to the specified renter.
+	FindContractsByRenter(renterID string) ([]core.Contract, error)
+	// Insert the given contract into the database.
+	InsertContract(contract core.Contract) error
+	// Update the given contract.
+	UpdateContract(contract core.Contract) error
+	// Delete the contract.
+	DeleteContract(contractID string) error
 }

--- a/metaserver/files.go
+++ b/metaserver/files.go
@@ -10,12 +10,33 @@ import (
 )
 
 type fileResp struct {
-	File  core.File `json:"file,omitempty"`
-	Error string    `json:"error,omitempty"`
+	FileID core.File `json:"file,omitempty"`
+	Error  string    `json:"error,omitempty"`
+}
+
+func (server *metaServer) getFilesHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		// Make sure the specified renter actually exists.
+		renter, err := server.db.FindRenterByID(params["renterID"])
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			resp := fileResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		// Retrieve the renter's files.
+		files, err := server.db.FindFilesInRenterDirectory(renter.ID)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			server.logger.Println(err)
+			return
+		}
+		json.NewEncoder(w).Encode(files)
+	})
 }
 
 func (server *metaServer) postFileHandler() http.HandlerFunc {
-	// BUG(kincaid): Validate that the file's owner id matches the user's
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var file core.File
 		err := json.NewDecoder(r.Body).Decode(&file)
@@ -26,6 +47,7 @@ func (server *metaServer) postFileHandler() http.HandlerFunc {
 			return
 		}
 
+		// BUG(kincaid): DB will throw error if file already exists. Might want to check explicitly.
 		err = server.db.InsertFile(file)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
@@ -50,31 +72,68 @@ func (server *metaServer) getFileHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) getFileVersionHandler() http.HandlerFunc {
+func (server *metaServer) deleteFileHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
 		params := mux.Vars(r)
-		version, err := strconv.Atoi(params["version"])
+		// BUG(kincaid): Make sure the renter owns the file they are deleting.
+		// Delete the file from the database.
+		err := server.db.DeleteFile(params["fileID"])
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			resp := fileResp{Error: "must supply int for version"}
+			resp := fileResp{Error: err.Error()}
 			json.NewEncoder(w).Encode(resp)
 			return
 		}
-		file, err := server.db.FindFileByIDAndVersion(params["id"], version)
+		// Remove the file from the renter's directory.
+		renter, err := server.db.FindRenterByID(params["renterID"])
 		if err != nil {
-			w.WriteHeader(http.StatusNotFound)
+			server.logger.Println(err)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		json.NewEncoder(w).Encode(file)
+		removeIndex := -1
+		for i, fileID := range renter.Files {
+			if fileID == params["fileID"] {
+				removeIndex = i
+			}
+		}
+		if removeIndex == -1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			server.logger.Println("could not find file in renter's directory")
+			return
+		}
+		renter.Files = append(renter.Files[:removeIndex], renter.Files[removeIndex+1:]...)
+		err = server.db.UpdateRenter(*renter)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			server.logger.Println(err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
 	})
 }
 
-func (server *metaServer) deleteFileHandler() http.HandlerFunc {
+func (server *metaServer) putFileHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
 		params := mux.Vars(r)
-		err := server.db.DeleteFile(params["id"])
+
+		var file core.File
+		err := json.NewDecoder(r.Body).Decode(&file)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := fileResp{Error: "could not parse payload"}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if file.ID != params["fileID"] {
+			w.WriteHeader(http.StatusUnauthorized)
+			resp := fileResp{Error: "must not change file ID"}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		err = server.db.UpdateFile(file)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			resp := fileResp{Error: err.Error()}
@@ -82,6 +141,51 @@ func (server *metaServer) deleteFileHandler() http.HandlerFunc {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func (server *metaServer) getFileVersionHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
+		params := mux.Vars(r)
+		versionNum, err := strconv.Atoi(params["version"])
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := fileResp{Error: "must supply int for version"}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		file, err := server.db.FindFileByID(params["id"])
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			resp := fileResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		for _, item := range file.Versions {
+			if item.Number == versionNum {
+				json.NewEncoder(w).Encode(item)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+		resp := fileResp{Error: "could not find specified version"}
+		json.NewEncoder(w).Encode(resp)
+	})
+}
+
+func (server *metaServer) getFileVersionsHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
+		params := mux.Vars(r)
+		file, err := server.db.FindFileByID(params["id"])
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			resp := fileResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		json.NewEncoder(w).Encode(file.Versions)
 	})
 }
 
@@ -96,13 +200,117 @@ func (server *metaServer) deleteFileVersionHandler() http.HandlerFunc {
 			json.NewEncoder(w).Encode(resp)
 			return
 		}
-		err = server.db.DeleteFileVersion(params["id"], version)
+		file, err := server.db.FindFileByID(params["id"])
 		if err != nil {
-			w.WriteHeader(http.StatusBadRequest)
+			w.WriteHeader(http.StatusNotFound)
 			resp := fileResp{Error: err.Error()}
 			json.NewEncoder(w).Encode(resp)
 			return
 		}
+		removeIndex := -1
+		for i, item := range file.Versions {
+			if item.Number == version {
+				removeIndex = i
+				break
+			}
+		}
+		if removeIndex == -1 {
+			w.WriteHeader(http.StatusNotFound)
+			resp := fileResp{Error: "could not find specified version"}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		file.Versions = append(file.Versions[:removeIndex], file.Versions[removeIndex+1:]...)
+		err = server.db.UpdateFile(*file)
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			resp := fileResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func (server *metaServer) postFileVersionHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+
+		var version core.Version
+		err := json.NewDecoder(r.Body).Decode(&version)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := fileResp{Error: "could not parse payload"}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		file, err := server.db.FindFileByID(params["fileID"])
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			resp := fileResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+		}
+
+		// Add 1 for index shift, 1 to get version number
+		version.Number = len(file.Versions) + 2
+		file.Versions = append(file.Versions, version)
+
+		err = server.db.UpdateFile(*file)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			server.logger.Println(err)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func (server *metaServer) putFileVersionHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		version, err := strconv.Atoi(params["version"])
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := fileResp{Error: "must supply int for version"}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		var newVersion core.Version
+		err = json.NewDecoder(r.Body).Decode(&newVersion)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := fileResp{Error: "could not parse payload"}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		file, err := server.db.FindFileByID(params["fileID"])
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			resp := fileResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+		}
+
+		updateIndex := -1
+		for i, item := range file.Versions {
+			if item.Number == version {
+				updateIndex = i
+			}
+		}
+		if updateIndex == -1 {
+
+		}
+
+		err = server.db.UpdateFile(*file)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			server.logger.Println(err)
+			return
+		}
+
 		w.WriteHeader(http.StatusOK)
 	})
 }

--- a/metaserver/files.go
+++ b/metaserver/files.go
@@ -14,7 +14,7 @@ type fileResp struct {
 	Error  string    `json:"error,omitempty"`
 }
 
-func (server *metaServer) getFilesHandler() http.HandlerFunc {
+func (server *MetaServer) getFilesHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		// Make sure the specified renter actually exists.
@@ -38,7 +38,7 @@ func (server *metaServer) getFilesHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) postFileHandler() http.HandlerFunc {
+func (server *MetaServer) postFileHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var file core.File
 		err := json.NewDecoder(r.Body).Decode(&file)
@@ -87,7 +87,7 @@ func (server *metaServer) postFileHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) getFileHandler() http.HandlerFunc {
+func (server *MetaServer) getFileHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
 		params := mux.Vars(r)
@@ -103,7 +103,7 @@ func (server *metaServer) getFileHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) deleteFileHandler() http.HandlerFunc {
+func (server *MetaServer) deleteFileHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		// BUG(kincaid): Make sure the renter owns the file they are deleting.
@@ -149,7 +149,7 @@ func (server *metaServer) deleteFileHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) putFileHandler() http.HandlerFunc {
+func (server *MetaServer) putFileHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 
@@ -185,7 +185,7 @@ func (server *metaServer) putFileHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) getFileVersionHandler() http.HandlerFunc {
+func (server *MetaServer) getFileVersionHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
 		params := mux.Vars(r)
@@ -215,7 +215,7 @@ func (server *metaServer) getFileVersionHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) getFileVersionsHandler() http.HandlerFunc {
+func (server *MetaServer) getFileVersionsHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
 		params := mux.Vars(r)
@@ -230,7 +230,7 @@ func (server *metaServer) getFileVersionsHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) deleteFileVersionHandler() http.HandlerFunc {
+func (server *MetaServer) deleteFileVersionHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
 		params := mux.Vars(r)
@@ -273,7 +273,7 @@ func (server *metaServer) deleteFileVersionHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) postFileVersionHandler() http.HandlerFunc {
+func (server *MetaServer) postFileVersionHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 
@@ -311,7 +311,7 @@ func (server *metaServer) postFileVersionHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) putFileVersionHandler() http.HandlerFunc {
+func (server *MetaServer) putFileVersionHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		version, err := strconv.Atoi(params["version"])
@@ -367,7 +367,7 @@ func (server *metaServer) putFileVersionHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) getFilePermissionsHandler() http.HandlerFunc {
+func (server *MetaServer) getFilePermissionsHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
 		params := mux.Vars(r)
@@ -382,7 +382,7 @@ func (server *metaServer) getFilePermissionsHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) getFilePermissionHandler() http.HandlerFunc {
+func (server *MetaServer) getFilePermissionHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
 		params := mux.Vars(r)
@@ -406,7 +406,7 @@ func (server *metaServer) getFilePermissionHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) postFilePermissionHandler() http.HandlerFunc {
+func (server *MetaServer) postFilePermissionHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 
@@ -472,7 +472,7 @@ func (server *metaServer) postFilePermissionHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) putFilePermissionHandler() http.HandlerFunc {
+func (server *MetaServer) putFilePermissionHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 
@@ -521,7 +521,7 @@ func (server *metaServer) putFilePermissionHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) deleteFilePermissionHandler() http.HandlerFunc {
+func (server *MetaServer) deleteFilePermissionHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
 		params := mux.Vars(r)

--- a/metaserver/files.go
+++ b/metaserver/files.go
@@ -187,7 +187,7 @@ func (server *metaServer) getFileVersionHandler() http.HandlerFunc {
 			json.NewEncoder(w).Encode(resp)
 			return
 		}
-		file, err := server.db.FindFileByID(params["id"])
+		file, err := server.db.FindFileByID(params["fileID"])
 		if err != nil {
 			w.WriteHeader(http.StatusNotFound)
 			resp := fileResp{Error: err.Error()}
@@ -285,7 +285,7 @@ func (server *metaServer) postFileVersionHandler() http.HandlerFunc {
 		}
 
 		// Add 1 for index shift, 1 to get version number
-		version.Number = len(file.Versions) + 2
+		version.Number = len(file.Versions) + 1
 		file.Versions = append(file.Versions, version)
 
 		err = server.db.UpdateFile(*file)
@@ -295,7 +295,7 @@ func (server *metaServer) postFileVersionHandler() http.HandlerFunc {
 			return
 		}
 
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusCreated)
 	})
 }
 

--- a/metaserver/files.go
+++ b/metaserver/files.go
@@ -1,0 +1,108 @@
+package metaserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"skybin/core"
+	"strconv"
+
+	"github.com/gorilla/mux"
+)
+
+type fileResp struct {
+	File  core.File `json:"file,omitempty"`
+	Error string    `json:"error,omitempty"`
+}
+
+func (server *metaServer) postFileHandler() http.HandlerFunc {
+	// BUG(kincaid): Validate that the file's owner id matches the user's
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var file core.File
+		err := json.NewDecoder(r.Body).Decode(&file)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := fileResp{Error: "could not parse body"}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		err = server.db.InsertFile(file)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := fileResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		json.NewEncoder(w).Encode(file)
+	})
+}
+
+func (server *metaServer) getFileHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
+		params := mux.Vars(r)
+		file, err := server.db.FindFileByID(params["id"])
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(file)
+	})
+}
+
+func (server *metaServer) getFileVersionHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
+		params := mux.Vars(r)
+		version, err := strconv.Atoi(params["version"])
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := fileResp{Error: "must supply int for version"}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		file, err := server.db.FindFileByIDAndVersion(params["id"], version)
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(file)
+	})
+}
+
+func (server *metaServer) deleteFileHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
+		params := mux.Vars(r)
+		err := server.db.DeleteFile(params["id"])
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := fileResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func (server *metaServer) deleteFileVersionHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// BUG(kincaid): Validate that the file's owner id matches the user's or the user is in the file's ACL
+		params := mux.Vars(r)
+		version, err := strconv.Atoi(params["version"])
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := fileResp{Error: "must supply int for version"}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		err = server.db.DeleteFileVersion(params["id"], version)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			resp := fileResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/metaserver/files.go
+++ b/metaserver/files.go
@@ -64,7 +64,7 @@ func (server *metaServer) postFileHandler() http.HandlerFunc {
 		file.OwnerID = params["renterID"]
 
 		// BUG(kincaid): DB will throw error if file already exists. Might want to check explicitly.
-		err = server.db.InsertFile(file)
+		err = server.db.InsertFile(&file)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			resp := fileResp{Error: err.Error()}
@@ -75,7 +75,7 @@ func (server *metaServer) postFileHandler() http.HandlerFunc {
 		// Insert the file's ID into the renter's directory.
 		renter.Files = append(renter.Files, file.ID)
 		// BUG(kincaid): Consider trying to roll things back if this fails.
-		err = server.db.UpdateRenter(*renter)
+		err = server.db.UpdateRenter(renter)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			resp := fileResp{Error: err.Error()}
@@ -137,7 +137,7 @@ func (server *metaServer) deleteFileHandler() http.HandlerFunc {
 			return
 		}
 		renter.Files = append(renter.Files[:removeIndex], renter.Files[removeIndex+1:]...)
-		err = server.db.UpdateRenter(*renter)
+		err = server.db.UpdateRenter(renter)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
@@ -174,7 +174,7 @@ func (server *metaServer) putFileHandler() http.HandlerFunc {
 			return
 		}
 
-		err = server.db.UpdateFile(file)
+		err = server.db.UpdateFile(&file)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			resp := fileResp{Error: err.Error()}
@@ -262,7 +262,7 @@ func (server *metaServer) deleteFileVersionHandler() http.HandlerFunc {
 			return
 		}
 		file.Versions = append(file.Versions[:removeIndex], file.Versions[removeIndex+1:]...)
-		err = server.db.UpdateFile(*file)
+		err = server.db.UpdateFile(file)
 		if err != nil {
 			w.WriteHeader(http.StatusNotFound)
 			resp := fileResp{Error: err.Error()}
@@ -298,7 +298,7 @@ func (server *metaServer) postFileVersionHandler() http.HandlerFunc {
 		version.Number = len(file.Versions) + 1
 		file.Versions = append(file.Versions, version)
 
-		err = server.db.UpdateFile(*file)
+		err = server.db.UpdateFile(file)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
@@ -354,7 +354,7 @@ func (server *metaServer) putFileVersionHandler() http.HandlerFunc {
 
 		file.Versions[updateIndex] = newVersion
 
-		err = server.db.UpdateFile(*file)
+		err = server.db.UpdateFile(file)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
@@ -448,7 +448,7 @@ func (server *metaServer) postFilePermissionHandler() http.HandlerFunc {
 
 		// Add the permission to the file's ACL
 		file.AccessList = append(file.AccessList, permission)
-		err = server.db.UpdateFile(*file)
+		err = server.db.UpdateFile(file)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
@@ -459,7 +459,7 @@ func (server *metaServer) postFilePermissionHandler() http.HandlerFunc {
 
 		// Add the file's ID to the renter's directory
 		renter.Shared = append(renter.Shared, file.ID)
-		err = server.db.UpdateRenter(*renter)
+		err = server.db.UpdateRenter(renter)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
@@ -508,7 +508,7 @@ func (server *metaServer) putFilePermissionHandler() http.HandlerFunc {
 
 		file.AccessList[updateIndex] = newPermission
 
-		err = server.db.UpdateFile(*file)
+		err = server.db.UpdateFile(file)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
@@ -548,7 +548,7 @@ func (server *metaServer) deleteFilePermissionHandler() http.HandlerFunc {
 			return
 		}
 		file.AccessList = append(file.AccessList[:removeIndex], file.AccessList[removeIndex+1:]...)
-		err = server.db.UpdateFile(*file)
+		err = server.db.UpdateFile(file)
 		if err != nil {
 			w.WriteHeader(http.StatusNotFound)
 			resp := fileResp{Error: err.Error()}
@@ -580,7 +580,7 @@ func (server *metaServer) deleteFilePermissionHandler() http.HandlerFunc {
 		}
 		renter.Shared = append(renter.Shared[:removeIndex], renter.Shared[removeIndex+1:]...)
 
-		err = server.db.UpdateRenter(*renter)
+		err = server.db.UpdateRenter(renter)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)

--- a/metaserver/files.go
+++ b/metaserver/files.go
@@ -30,6 +30,8 @@ func (server *metaServer) getFilesHandler() http.HandlerFunc {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
+			resp := errorResp{Error: "internal server errorr"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 		json.NewEncoder(w).Encode(files)
@@ -93,6 +95,8 @@ func (server *metaServer) getFileHandler() http.HandlerFunc {
 		if err != nil {
 			w.WriteHeader(http.StatusNotFound)
 			server.logger.Println(err)
+			resp := errorResp{Error: "could not find file"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 		json.NewEncoder(w).Encode(file)
@@ -114,8 +118,9 @@ func (server *metaServer) deleteFileHandler() http.HandlerFunc {
 		// Remove the file from the renter's directory.
 		renter, err := server.db.FindRenterByID(params["renterID"])
 		if err != nil {
-			server.logger.Println(err)
 			w.WriteHeader(http.StatusInternalServerError)
+			resp := errorResp{Error: "could not find renter"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 		removeIndex := -1
@@ -127,6 +132,8 @@ func (server *metaServer) deleteFileHandler() http.HandlerFunc {
 		if removeIndex == -1 {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println("could not find file in renter's directory")
+			resp := errorResp{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 		renter.Files = append(renter.Files[:removeIndex], renter.Files[removeIndex+1:]...)
@@ -134,6 +141,8 @@ func (server *metaServer) deleteFileHandler() http.HandlerFunc {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
+			resp := errorResp{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -293,6 +302,8 @@ func (server *metaServer) postFileVersionHandler() http.HandlerFunc {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
+			resp := errorResp{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
@@ -336,6 +347,8 @@ func (server *metaServer) putFileVersionHandler() http.HandlerFunc {
 		}
 		if updateIndex == -1 {
 			w.WriteHeader(http.StatusNotFound)
+			resp := errorResp{Error: "version not found"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
@@ -345,6 +358,8 @@ func (server *metaServer) putFileVersionHandler() http.HandlerFunc {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
+			resp := errorResp{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
@@ -437,6 +452,8 @@ func (server *metaServer) postFilePermissionHandler() http.HandlerFunc {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
+			resp := errorResp{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
@@ -446,6 +463,8 @@ func (server *metaServer) postFilePermissionHandler() http.HandlerFunc {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
+			resp := errorResp{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
@@ -482,6 +501,8 @@ func (server *metaServer) putFilePermissionHandler() http.HandlerFunc {
 		}
 		if updateIndex == -1 {
 			w.WriteHeader(http.StatusNotFound)
+			resp := errorResp{Error: "permission not found"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
@@ -491,6 +512,8 @@ func (server *metaServer) putFilePermissionHandler() http.HandlerFunc {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
+			resp := errorResp{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
@@ -538,6 +561,8 @@ func (server *metaServer) deleteFilePermissionHandler() http.HandlerFunc {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
+			resp := errorResp{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
@@ -559,6 +584,8 @@ func (server *metaServer) deleteFilePermissionHandler() http.HandlerFunc {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
+			resp := errorResp{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 

--- a/metaserver/json.go
+++ b/metaserver/json.go
@@ -1,0 +1,298 @@
+package metaserver
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+	"path"
+	"skybin/core"
+)
+
+type jsonDB struct {
+	providers []core.ProviderInfo
+	renters   []core.RenterInfo
+	files     []core.File
+	path      string
+}
+
+type storageFile struct {
+	Providers []core.ProviderInfo
+	Renters   []core.RenterInfo
+}
+
+func newJsonDB(dbLocation string) jsonDB {
+	db := jsonDB{}
+
+	if _, err := os.Stat(dbLocation); os.IsNotExist(err) {
+		db.dumpDbToFile()
+	} else {
+		db.loadDbFromFile()
+	}
+
+	return db
+}
+
+func (db jsonDB) dumpDbToFile() {
+	storageFile := storageFile{Providers: db.providers, Renters: db.renters}
+
+	dbBytes, err := json.Marshal(storageFile)
+	if err != nil {
+		panic(err)
+	}
+
+	writeErr := ioutil.WriteFile(path.Join(db.path), dbBytes, 0644)
+	if writeErr != nil {
+		panic(err)
+	}
+}
+
+func (db jsonDB) loadDbFromFile() {
+	contents, err := ioutil.ReadFile(path.Join(db.path))
+	if err != nil {
+		panic(err)
+	}
+
+	var newInfo storageFile
+
+	parseErr := json.Unmarshal(contents, &newInfo)
+	if parseErr != nil {
+		panic(parseErr)
+	}
+
+	db.providers = newInfo.Providers
+	db.renters = newInfo.Renters
+}
+
+// Renter operations
+
+func (db jsonDB) FindAllRenters() []core.RenterInfo {
+	return db.renters
+}
+
+func (db jsonDB) FindRenterByID(id string) (core.RenterInfo, error) {
+	for _, renter := range db.renters {
+		if renter.ID == id {
+			return renter, nil
+		}
+	}
+	return core.RenterInfo{}, errors.New("could not locate renter with given ID")
+}
+
+func (db jsonDB) InsertRenter(newRenter core.RenterInfo) error {
+	for _, renter := range db.renters {
+		if newRenter.ID == renter.ID {
+			return errors.New("renter with given ID already exists")
+		}
+	}
+	db.renters = append(db.renters, newRenter)
+	db.dumpDbToFile()
+	return nil
+}
+
+func (db jsonDB) UpdateRenter(updateRenter core.RenterInfo) error {
+	foundRenter := false
+	var replaceIndex int
+
+	for i, renter := range db.renters {
+		if updateRenter.ID == renter.ID {
+			replaceIndex = i
+			foundRenter = true
+		}
+	}
+
+	if !foundRenter {
+		return errors.New("could not find renter with given ID")
+	}
+
+	db.renters[replaceIndex] = updateRenter
+	db.dumpDbToFile()
+	return nil
+}
+
+func (db jsonDB) DeleteRenter(renterID string) error {
+	removeIndex := -1
+	for i, renter := range db.renters {
+		if renterID == renter.ID {
+			removeIndex = i
+		}
+	}
+	if removeIndex == -1 {
+		return errors.New("no renter with given ID")
+	}
+	db.renters = append(db.renters[:removeIndex], db.renters[removeIndex+1:]...)
+	db.dumpDbToFile()
+	return nil
+}
+
+// Provider operations
+func (db jsonDB) FindAllProviders() []core.ProviderInfo {
+	return db.providers
+}
+
+func (db jsonDB) FindProviderByID(id string) (core.ProviderInfo, error) {
+	for _, provider := range db.providers {
+		if provider.ID == id {
+			return provider, nil
+		}
+	}
+	return core.ProviderInfo{}, errors.New("could not locate provider with given ID")
+}
+
+func (db jsonDB) InsertProvider(newProvider core.ProviderInfo) error {
+	for _, provider := range db.providers {
+		if newProvider.ID == provider.ID {
+			return errors.New("provider with given ID already exists")
+		}
+	}
+	db.providers = append(db.providers, newProvider)
+	db.dumpDbToFile()
+	return nil
+}
+
+func (db jsonDB) UpdateProvider(updateProvider core.ProviderInfo) error {
+	foundProvider := false
+	var replaceIndex int
+
+	for i, provider := range db.providers {
+		if updateProvider.ID == provider.ID {
+			replaceIndex = i
+			foundProvider = true
+		}
+	}
+
+	if !foundProvider {
+		return errors.New("could not find provider with given ID")
+	}
+
+	db.providers[replaceIndex] = updateProvider
+	db.dumpDbToFile()
+	return nil
+}
+
+func (db jsonDB) DeleteProvider(providerID string) error {
+	removeIndex := -1
+	for i, provider := range db.providers {
+		if providerID == provider.ID {
+			removeIndex = i
+		}
+	}
+	if removeIndex == -1 {
+		return errors.New("no provider with given ID")
+	}
+	db.providers = append(db.providers[:removeIndex], db.providers[removeIndex+1:]...)
+	db.dumpDbToFile()
+	return nil
+}
+
+// File operations
+
+func (db jsonDB) FindAllFiles() []core.File {
+	return db.files
+}
+
+func (db jsonDB) FindFileByID(fileID string) (core.File, error) {
+	var foundFiles []core.File
+	for _, file := range db.files {
+		if file.ID == fileID {
+			foundFiles = append(foundFiles, file)
+		}
+	}
+	if len(foundFiles) == 0 {
+		return core.File{}, errors.New("could not locate file with given ID")
+	}
+	highestVersionIndex := -1
+	highestVersionFound := -1
+	for i, file := range foundFiles {
+		if file.VersionNum > highestVersionFound {
+			highestVersionIndex = i
+			highestVersionFound = file.VersionNum
+		}
+	}
+	return foundFiles[highestVersionIndex], nil
+}
+
+func (db jsonDB) FindFileByIDAndVersion(fileID string, version int) (core.File, error) {
+	for _, file := range db.files {
+		if file.ID == fileID && file.VersionNum == version {
+			return file, nil
+		}
+	}
+	return core.File{}, errors.New("no file with specified ID and version")
+}
+
+func (db jsonDB) InsertFile(newFile core.File) error {
+	var renter core.RenterInfo
+	foundRenter := false
+	for _, item := range db.renters {
+		if item.ID == newFile.OwnerID {
+			foundRenter = true
+		}
+	}
+	if !foundRenter {
+		return errors.New("no renter matching ownerID")
+	}
+	for _, file := range db.files {
+		if file.ID == newFile.ID && file.VersionNum == newFile.VersionNum {
+			return errors.New("there is already a file with the given ID and version")
+		}
+	}
+	db.files = append(db.files, newFile)
+	db.dumpDbToFile()
+	return nil
+}
+
+func (db jsonDB) UpdateFile(updateFile core.File) error {
+	var renter core.RenterInfo
+	foundRenter := false
+	for _, item := range db.renters {
+		if item.ID == updateFile.OwnerID {
+			foundRenter = true
+		}
+	}
+	if !foundRenter {
+		return errors.New("no renter matching ownerID")
+	}
+	updateIndex := -1
+	for i, file := range db.files {
+		if file.ID == updateFile.ID && file.VersionNum == updateFile.VersionNum {
+			updateIndex = i
+		}
+	}
+	if updateIndex == -1 {
+		return errors.New("could not locate file with specified ID and version")
+	}
+	db.files[updateIndex] = updateFile
+	db.dumpDbToFile()
+	return nil
+}
+
+func (db jsonDB) DeleteFile(fileID string) error {
+	var keepFiles []core.File
+	for _, file := range db.files {
+		if file.ID != fileID {
+			keepFiles = append(keepFiles, file)
+		}
+	}
+	if len(keepFiles) == len(db.files) {
+		return errors.New("no files with specified ID")
+	}
+	db.files = keepFiles
+	db.dumpDbToFile()
+	return nil
+}
+
+func (db jsonDB) DeleteFileVersion(fileID string, versionNum int) error {
+	deleteIndex := -1
+	for i, file := range db.files {
+		if file.ID == fileID && file.VersionNum == versionNum {
+			deleteIndex = i
+		}
+	}
+	if deleteIndex == -1 {
+		return errors.New("could not locate file with specified ID and version")
+	}
+	db.files = append(db.files[:deleteIndex], db.files[deleteIndex+1:]...)
+	db.dumpDbToFile()
+	return nil
+}

--- a/metaserver/metaserver_test.go
+++ b/metaserver/metaserver_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"skybin/core"
 	"testing"
+	"time"
 
 	"github.com/go-test/deep"
 )
@@ -469,12 +470,12 @@ func TestDeleteFile(t *testing.T) {
 }
 
 // Post new version of file
-func blahTestUploadNewFileVersion(t *testing.T) {
+func TestUploadNewFileVersion(t *testing.T) {
 	httpClient := http.Client{}
 	client := NewClient(core.DefaultMetaAddr, &httpClient)
 
 	// Register a renter
-	renter, err := registerRenter(client, "fileUploadTest")
+	renter, err := registerRenter(client, "fileUploadVersionTest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -485,40 +486,37 @@ func blahTestUploadNewFileVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Retrieve the file and make sure it matches what we posted and has the proper owner.
-	result, err := client.GetFile(renter.ID, file.ID)
+	// Upload a new version of the file.
+	version := core.Version{
+		Blocks:  make([]core.Block, 0),
+		Size:    1000,
+		ModTime: time.Time{},
+	}
+
+	err = client.PostFileVersion(renter.ID, file.ID, version)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	file.OwnerID = renter.ID
-	if diff := deep.Equal(file, *result); diff != nil {
+	// Retrieve the version and make sure it matches.
+	version.Number = 1
+
+	result, err := client.GetFileVersion(renter.ID, file.ID, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := deep.Equal(version, *result); diff != nil {
 		t.Fatal(diff)
-	}
-
-	// Make sure the file shows up in the renter's files.
-	renter, err = client.GetRenter(renter.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	foundFile := false
-	for _, item := range renter.Files {
-		if item == file.ID {
-			foundFile = true
-			break
-		}
-	}
-	if !foundFile {
-		t.Fatal("file not added to renter's directory")
 	}
 }
 
+// Get all versions of file
+// Delete version of file
+// Update file version
+
 // Get shared files
 // Get shared file
-// Get all versions of file
-// Get version of file
-// Delete version of file
 // Share file
 // Get shared file
 // Unshare file

--- a/metaserver/metaserver_test.go
+++ b/metaserver/metaserver_test.go
@@ -118,7 +118,29 @@ func TestUpdateRenter(t *testing.T) {
 	if diff := deep.Equal(renter, updatedRenter); diff != nil {
 		t.Fatal(diff)
 	}
+
 	// Make sure we can't update the ID, alias, or public key.
+	oldID := renter.ID
+	renter.ID = "foo"
+	err = client.UpdateRenter(renter)
+	if err == nil {
+		t.Fatal("was able to update renter ID")
+	}
+	renter.ID = oldID
+
+	oldAlias := renter.Alias
+	renter.Alias = "foo"
+	err = client.UpdateRenter(renter)
+	if err == nil {
+		t.Fatal("was able to update renter alias")
+	}
+	renter.Alias = oldAlias
+
+	renter.PublicKey = "foo"
+	err = client.UpdateRenter(renter)
+	if err == nil {
+		t.Fatal("was able to update renter public key")
+	}
 }
 
 // Get renter info

--- a/metaserver/metaserver_test.go
+++ b/metaserver/metaserver_test.go
@@ -62,6 +62,8 @@ func TestMetaserverRenterRegistration(t *testing.T) {
 	renter := core.RenterInfo{
 		PublicKey: publicKeyString,
 		Alias:     "testRenterReg",
+		Shared:    make([]string, 0),
+		Files:     make([]string, 0),
 	}
 
 	err = client.RegisterRenter(&renter)
@@ -80,6 +82,8 @@ func TestMetaserverRenterRegistration(t *testing.T) {
 		PublicKey: publicKeyString,
 		Alias:     "testRenterReg",
 		ID:        renterID,
+		Shared:    make([]string, 0),
+		Files:     make([]string, 0),
 	}
 
 	returned, err := client.GetRenter(renterID)
@@ -87,8 +91,8 @@ func TestMetaserverRenterRegistration(t *testing.T) {
 		t.Fatal("encountered error while attempting to retrieve registered renter info: ", err)
 	}
 
-	if returned.Alias != expected.Alias || returned.ID != expected.ID || returned.PublicKey != expected.PublicKey {
-		t.Fatal("Expected ", expected, ", received ", expected)
+	if diff := deep.Equal(expected, returned); diff != nil {
+		t.Fatal(diff)
 	}
 }
 
@@ -143,8 +147,29 @@ func TestUpdateRenter(t *testing.T) {
 	}
 }
 
-// Get renter info
 // Delete renter
+func TestDeleteRenter(t *testing.T) {
+	httpClient := http.Client{}
+	client := NewClient(core.DefaultMetaAddr, &httpClient)
+
+	// Register a renter.
+	renter, err := registerRenter(client, "renterDeleteTest")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the renter.
+	err = client.DeleteRenter(renter.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attempt to get the renter's information.
+	_, err = client.GetRenter(renter.ID)
+	if err == nil {
+		t.Fatal("was able to retrieve deleted renter")
+	}
+}
 
 // POST contract
 // Get contracts

--- a/metaserver/metaserver_test.go
+++ b/metaserver/metaserver_test.go
@@ -683,7 +683,7 @@ func TestShareFile(t *testing.T) {
 
 	// Share the file
 	permission := core.Permission{
-		UserId: sharedWith.ID,
+		RenterId: sharedWith.ID,
 	}
 	err = client.ShareFile(sharer.ID, file.ID, permission)
 	if err != nil {
@@ -704,7 +704,7 @@ func TestShareFile(t *testing.T) {
 
 	foundPermission := false
 	for _, item := range result.AccessList {
-		if item.UserId == sharedWith.ID {
+		if item.RenterId == sharedWith.ID {
 			foundPermission = true
 		}
 	}
@@ -738,7 +738,7 @@ func TestGetSharedFiles(t *testing.T) {
 
 	// Share the file
 	permission := core.Permission{
-		UserId: sharedWith.ID,
+		RenterId: sharedWith.ID,
 	}
 	err = client.ShareFile(sharer.ID, file.ID, permission)
 	if err != nil {
@@ -788,7 +788,7 @@ func TestUnshareFile(t *testing.T) {
 
 	// Share the file
 	permission := core.Permission{
-		UserId: sharedWith.ID,
+		RenterId: sharedWith.ID,
 	}
 	err = client.ShareFile(sharer.ID, file.ID, permission)
 	if err != nil {
@@ -847,7 +847,7 @@ func TestRemoveSharedFile(t *testing.T) {
 
 	// Share the file
 	permission := core.Permission{
-		UserId: sharedWith.ID,
+		RenterId: sharedWith.ID,
 	}
 	err = client.ShareFile(sharer.ID, file.ID, permission)
 	if err != nil {

--- a/metaserver/metaserver_test.go
+++ b/metaserver/metaserver_test.go
@@ -198,7 +198,7 @@ func TestPostContract(t *testing.T) {
 		ID:       "contractUploadTest",
 		RenterId: renter.ID,
 	}
-	err = client.PostContract(renter.ID, contract)
+	err = client.PostContract(renter.ID, &contract)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -232,7 +232,7 @@ func TestGetContracts(t *testing.T) {
 			ID:       contractName,
 			RenterId: renter.ID,
 		}
-		err = client.PostContract(renter.ID, contract)
+		err = client.PostContract(renter.ID, &contract)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -276,7 +276,7 @@ func TestDeleteContract(t *testing.T) {
 		ID:       "contractDeleteTest",
 		RenterId: renter.ID,
 	}
-	err = client.PostContract(renter.ID, contract)
+	err = client.PostContract(renter.ID, &contract)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +387,7 @@ func uploadFile(client *Client, renterID string, ID string, name string) (*core.
 		AccessList: make([]core.Permission, 0),
 		Versions:   make([]core.Version, 0),
 	}
-	err := client.PostFile(renterID, file)
+	err := client.PostFile(renterID, &file)
 	if err != nil {
 		return nil, err
 	}
@@ -459,7 +459,7 @@ func TestUpdateFile(t *testing.T) {
 
 	// Update the file.
 	file.Name = "newName"
-	err = client.UpdateFile(renter.ID, *file)
+	err = client.UpdateFile(renter.ID, file)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -494,7 +494,7 @@ func TestUpdateFile(t *testing.T) {
 
 	// Make sure users can't update file's owner ID
 	file.OwnerID = "somebodyElseShouldPay"
-	err = client.UpdateFile(renter.ID, *file)
+	err = client.UpdateFile(renter.ID, file)
 	if err == nil {
 		t.Fatal("user allowed to update owner ID")
 	}
@@ -599,7 +599,7 @@ func TestUploadNewFileVersion(t *testing.T) {
 		ModTime: time.Time{},
 	}
 
-	err = client.PostFileVersion(renter.ID, file.ID, version)
+	err = client.PostFileVersion(renter.ID, file.ID, &version)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -642,7 +642,7 @@ func TestGetFileVersions(t *testing.T) {
 			Size:    1000,
 			ModTime: time.Time{},
 		}
-		err = client.PostFileVersion(renter.ID, file.ID, version)
+		err = client.PostFileVersion(renter.ID, file.ID, &version)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -697,7 +697,7 @@ func TestDeleteFileVersion(t *testing.T) {
 		ModTime: time.Time{},
 	}
 
-	err = client.PostFileVersion(renter.ID, file.ID, version)
+	err = client.PostFileVersion(renter.ID, file.ID, &version)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -740,7 +740,7 @@ func TestUpdateFileVersion(t *testing.T) {
 		ModTime: time.Time{},
 	}
 
-	err = client.PostFileVersion(renter.ID, file.ID, version)
+	err = client.PostFileVersion(renter.ID, file.ID, &version)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -749,7 +749,7 @@ func TestUpdateFileVersion(t *testing.T) {
 	version.Number = 1
 	version.Size = 2000
 
-	err = client.PutFileVersion(renter.ID, file.ID, version)
+	err = client.PutFileVersion(renter.ID, file.ID, &version)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -791,7 +791,7 @@ func TestShareFile(t *testing.T) {
 	permission := core.Permission{
 		RenterId: sharedWith.ID,
 	}
-	err = client.ShareFile(sharer.ID, file.ID, permission)
+	err = client.ShareFile(sharer.ID, file.ID, &permission)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -846,7 +846,7 @@ func TestGetSharedFiles(t *testing.T) {
 	permission := core.Permission{
 		RenterId: sharedWith.ID,
 	}
-	err = client.ShareFile(sharer.ID, file.ID, permission)
+	err = client.ShareFile(sharer.ID, file.ID, &permission)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -896,7 +896,7 @@ func TestUnshareFile(t *testing.T) {
 	permission := core.Permission{
 		RenterId: sharedWith.ID,
 	}
-	err = client.ShareFile(sharer.ID, file.ID, permission)
+	err = client.ShareFile(sharer.ID, file.ID, &permission)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -955,7 +955,7 @@ func TestRemoveSharedFile(t *testing.T) {
 	permission := core.Permission{
 		RenterId: sharedWith.ID,
 	}
-	err = client.ShareFile(sharer.ID, file.ID, permission)
+	err = client.ShareFile(sharer.ID, file.ID, &permission)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/metaserver/metaserver_test.go
+++ b/metaserver/metaserver_test.go
@@ -309,7 +309,7 @@ func TestRegisterProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if diff := deep.Equal(*provider, returned); diff != nil {
+	if diff := deep.Equal(provider, returned); diff != nil {
 		t.Fatal(diff)
 	}
 }
@@ -335,7 +335,7 @@ func TestUpdateProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if diff := deep.Equal(*provider, updatedProvider); diff != nil {
+	if diff := deep.Equal(provider, updatedProvider); diff != nil {
 		t.Fatal(diff)
 	}
 

--- a/metaserver/metaserver_test.go
+++ b/metaserver/metaserver_test.go
@@ -1,0 +1,151 @@
+package metaserver
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"net/http"
+	"skybin/core"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func registerRenter(client *Client, alias string) (*core.RenterInfo, error) {
+	// Generate an RSA key for registration.
+	reader := rand.Reader
+	rsaKey, err := rsa.GenerateKey(reader, 2048)
+	publicKeyString := getPublicKeyString(&rsaKey.PublicKey)
+	if err != nil {
+		panic("could not generate rsa key")
+	}
+
+	// Renter that will be registered.
+	renter := core.RenterInfo{
+		PublicKey: publicKeyString,
+		Alias:     alias,
+		Shared:    make([]string, 0),
+		Files:     make([]string, 0),
+	}
+
+	err = client.RegisterRenter(&renter)
+	if err != nil {
+		return nil, err
+	}
+
+	renterID := fingerprintKey(publicKeyString)
+	renter.ID = renterID
+
+	err = client.Authorize(rsaKey, renterID)
+	if err != nil {
+		return nil, errors.New("could not authorize")
+	}
+
+	return &renter, nil
+}
+
+// Check that renters can register with the metaserver.
+func TestMetaserverRenterRegistration(t *testing.T) {
+	// Create a client for testing.
+	httpClient := http.Client{}
+	client := NewClient(core.DefaultMetaAddr, &httpClient)
+
+	// Generate an RSA key for registration.
+	reader := rand.Reader
+	rsaKey, err := rsa.GenerateKey(reader, 2048)
+	publicKeyString := getPublicKeyString(&rsaKey.PublicKey)
+	if err != nil {
+		panic("could not generate rsa key")
+	}
+
+	// Renter that will be registered.
+	renter := core.RenterInfo{
+		PublicKey: publicKeyString,
+		Alias:     "testRenterReg",
+	}
+
+	err = client.RegisterRenter(&renter)
+	if err != nil {
+		t.Fatal("encountered error while registering renter: ", err)
+	}
+
+	renterID := fingerprintKey(publicKeyString)
+
+	err = client.Authorize(rsaKey, renterID)
+	if err != nil {
+		t.Fatal("encountered error while attempting to authorize with registered renter: ", err)
+	}
+
+	expected := &core.RenterInfo{
+		PublicKey: publicKeyString,
+		Alias:     "testRenterReg",
+		ID:        renterID,
+	}
+
+	returned, err := client.GetRenter(renterID)
+	if err != nil {
+		t.Fatal("encountered error while attempting to retrieve registered renter info: ", err)
+	}
+
+	if returned.Alias != expected.Alias || returned.ID != expected.ID || returned.PublicKey != expected.PublicKey {
+		t.Fatal("Expected ", expected, ", received ", expected)
+	}
+}
+
+// Update renter
+func TestUpdateRenter(t *testing.T) {
+	httpClient := http.Client{}
+	client := NewClient(core.DefaultMetaAddr, &httpClient)
+
+	// Register a renter.
+	renter, err := registerRenter(client, "renterUpdateTest")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Update the renter's information.
+	renter.Files = append(renter.Files, "hi")
+	err = client.UpdateRenter(renter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updatedRenter, err := client.GetRenter(renter.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := deep.Equal(renter, updatedRenter); diff != nil {
+		t.Fatal(diff)
+	}
+	// Make sure we can't update the ID, alias, or public key.
+}
+
+// Get renter info
+// Delete renter
+
+// POST contract
+// Get contracts
+// Get contract
+// Delete contract
+
+// Register provider
+// Update provider
+// List providers
+// Get provider
+// Delete provider
+
+// Get files
+// Get file
+// Get shared files
+// Get shared file
+// POST file
+// Update file
+// Get file
+// Delete file
+// Post new version of file
+// Get all versions of file
+// Get version of file
+// Delete version of file
+// Share file
+// Remove shared file

--- a/metaserver/mongoDB.go
+++ b/metaserver/mongoDB.go
@@ -238,8 +238,9 @@ func (db *mongoDB) FindFilesInRenterDirectory(renterID string) ([]core.File, err
 	// Get file IDs in renter directory.
 	renters := session.DB(dbName).C("renters")
 
+	selector := struct{ ID string }{ID: renterID}
 	var renter core.RenterInfo
-	err = renters.Find(nil).One(&renter)
+	err = renters.Find(selector).One(&renter)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +251,7 @@ func (db *mongoDB) FindFilesInRenterDirectory(renterID string) ([]core.File, err
 
 	var foundFiles []core.File
 	for _, item := range filesToFind {
-		selector := struct{ ID string }{ID: item}
+		selector = struct{ ID string }{ID: item}
 		var result core.File
 		err = files.Find(selector).One(&result)
 		if err != nil {

--- a/metaserver/mongoDB.go
+++ b/metaserver/mongoDB.go
@@ -1,0 +1,363 @@
+package metaserver
+
+import (
+	"skybin/core"
+
+	"github.com/globalsign/mgo"
+)
+
+const dbName = "skybin"
+const dbAddress = "127.0.0.1"
+
+type mongoDB struct{}
+
+func getMongoCollection(name string) (*mgo.Collection, *mgo.Session, error) {
+	session, err := mgo.Dial(dbAddress)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := session.DB(dbName).C(name)
+
+	return c, session, nil
+}
+
+// Renter operations
+//==================
+
+// Return a list of all renters in the database
+func (db *mongoDB) FindAllRenters() ([]core.RenterInfo, error) {
+	c, session, err := getMongoCollection("renters")
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	var result []core.RenterInfo
+	err = c.Find(nil).All(&result)
+
+	return result, nil
+}
+
+// Return the renter with the specified ID.
+func (db *mongoDB) FindRenterByID(renterID string) (*core.RenterInfo, error) {
+	c, session, err := getMongoCollection("renters")
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	var result core.RenterInfo
+	err = c.Find(nil).One(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// Insert the provided renter into the database.
+func (db *mongoDB) InsertRenter(renter core.RenterInfo) error {
+	c, session, err := getMongoCollection("renters")
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	err = c.Insert(renter)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Update the provided renter in the databse.
+func (db *mongoDB) UpdateRenter(renter core.RenterInfo) error {
+	c, session, err := getMongoCollection("renters")
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	selector := struct{ ID string }{ID: renter.ID}
+	err = c.Update(selector, renter)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete the specified renter from the database.
+func (db *mongoDB) DeleteRenter(renterID string) error {
+	c, session, err := getMongoCollection("renters")
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	selector := struct{ ID string }{ID: renterID}
+	err = c.Remove(selector)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Provider operations
+//====================
+
+// Return a list of all the providers in the database.
+func (db *mongoDB) FindAllProviders() ([]core.ProviderInfo, error) {
+	c, session, err := getMongoCollection("providers")
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	var result []core.ProviderInfo
+	err = c.Find(nil).All(&result)
+
+	return result, nil
+}
+
+// Return the provider with the specified ID.
+func (db *mongoDB) FindProviderByID(providerID string) (*core.ProviderInfo, error) {
+	c, session, err := getMongoCollection("providers")
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	var result core.ProviderInfo
+	err = c.Find(nil).One(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// Insert the given provider into the database.
+func (db *mongoDB) InsertProvider(provider core.ProviderInfo) error {
+	c, session, err := getMongoCollection("providers")
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	err = c.Insert(provider)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Update the given provider in the databse.
+func (db *mongoDB) UpdateProvider(provider core.ProviderInfo) error {
+	c, session, err := getMongoCollection("providers")
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	selector := struct{ ID string }{ID: provider.ID}
+	err = c.Update(selector, provider)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete the specified provider from the dtabase.
+func (db *mongoDB) DeleteProvider(providerID string) error {
+	c, session, err := getMongoCollection("renters")
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	selector := struct{ ID string }{ID: providerID}
+	err = c.Remove(selector)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// File operations
+//====================
+
+// Return a list of all files in the database.
+func (db *mongoDB) FindAllFiles() ([]core.File, error) {
+	c, session, err := getMongoCollection("files")
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	var result []core.File
+	err = c.Find(nil).All(&result)
+
+	return result, nil
+}
+
+// Return the latest version of the file with the specified ID.
+func (db *mongoDB) FindFileByID(fileID string) (*core.File, error) {
+	c, session, err := getMongoCollection("files")
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	var result core.File
+	err = c.Find(nil).One(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// Return a map of paths to files present in the renter's directory.
+func (db *mongoDB) FindFilesInRenterDirectory(renterID string) ([]core.File, error) {
+	session, err := mgo.Dial(dbAddress)
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	// Get file IDs in renter directory.
+	renters := session.DB(dbName).C("renters")
+
+	var renter core.RenterInfo
+	err = renters.Find(nil).One(&renter)
+	if err != nil {
+		return nil, err
+	}
+	filesToFind := renter.Files
+
+	// Retrieve files from collection.
+	files := session.DB(dbName).C("files")
+
+	selector := make([]struct{ ID string }, 0)
+	for _, file := range filesToFind {
+		selector = append(selector, struct{ ID string }{ID: file})
+	}
+
+	var foundFiles []core.File
+	err = files.Find(selector).All(&foundFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	return foundFiles, nil
+}
+
+// Return a map of names to files shared with a given renter.
+func (db *mongoDB) FindFilesSharedWithRenter(renterID string) ([]core.File, error) {
+	session, err := mgo.Dial(dbAddress)
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	// Get file IDs in renter directory.
+	renters := session.DB(dbName).C("renters")
+
+	var renter core.RenterInfo
+	err = renters.Find(nil).One(&renter)
+	if err != nil {
+		return nil, err
+	}
+	filesToFind := renter.Shared
+
+	// Retrieve files from collection.
+	files := session.DB(dbName).C("files")
+
+	selector := make([]struct{ ID string }, 0)
+	for _, file := range filesToFind {
+		selector = append(selector, struct{ ID string }{ID: file})
+	}
+
+	var foundFiles []core.File
+	err = files.Find(selector).All(&foundFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	return foundFiles, nil
+}
+
+// Return a list of files that the renter owns.
+func (db *mongoDB) FindFilesByOwner(renterID string) ([]core.File, error) {
+	c, session, err := getMongoCollection("files")
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	var result []core.File
+	selector := struct{ ownerID string }{ownerID: renterID}
+	err = c.Find(selector).All(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// Insert the given file into the database.
+func (db *mongoDB) InsertFile(file core.File) error {
+	c, session, err := getMongoCollection("files")
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	err = c.Insert(file)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Update the given file in the database.
+func (db *mongoDB) UpdateFile(file core.File) error {
+	c, session, err := getMongoCollection("files")
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	selector := struct{ ID string }{ID: file.ID}
+	err = c.Update(selector, file)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete all versions of the given file from the database.
+func (db *mongoDB) DeleteFile(fileID string) error {
+	c, session, err := getMongoCollection("files")
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	selector := struct{ ID string }{ID: fileID}
+	err = c.Remove(selector)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/metaserver/mongoDB.go
+++ b/metaserver/mongoDB.go
@@ -393,7 +393,7 @@ func (db *mongoDB) FindContractByID(contractID string) (*core.Contract, error) {
 	defer session.Close()
 
 	selector := struct{ ID string }{ID: contractID}
-	var result core.File
+	var result core.Contract
 	err = c.Find(selector).One(&result)
 	if err != nil {
 		return nil, err
@@ -454,7 +454,7 @@ func (db *mongoDB) UpdateContract(contract core.Contract) error {
 }
 
 // Delete the contract.
-func DeleteContract(contractID string) error {
+func (db *mongoDB) DeleteContract(contractID string) error {
 	c, session, err := getMongoCollection("contracts")
 	if err != nil {
 		return err

--- a/metaserver/mongoDB.go
+++ b/metaserver/mongoDB.go
@@ -366,3 +366,106 @@ func (db *mongoDB) DeleteFile(fileID string) error {
 
 	return nil
 }
+
+// Contract operations
+//====================
+
+// Return a list of all contracts in the database.
+func (db *mongoDB) FindAllContracts() ([]core.Contract, error) {
+	c, session, err := getMongoCollection("contracts")
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	var result []core.Contract
+	err = c.Find(nil).All(&result)
+
+	return result, nil
+}
+
+// Return the contract with the specified ID
+func (db *mongoDB) FindContractByID(contractID string) (*core.Contract, error) {
+	c, session, err := getMongoCollection("contracts")
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	selector := struct{ ID string }{ID: contractID}
+	var result core.File
+	err = c.Find(selector).One(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// Return a list of contracts belonging to the specified renter.
+func (db *mongoDB) FindContractsByRenter(renterID string) ([]core.Contract, error) {
+	c, session, err := getMongoCollection("contracts")
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	var result []core.Contract
+	selector := struct{ renterId string }{renterId: renterID}
+	err = c.Find(selector).All(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// Insert the given contract into the database.
+func (db *mongoDB) InsertContract(contract core.Contract) error {
+	c, session, err := getMongoCollection("contracts")
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	err = c.Insert(contract)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Update the given contract.
+func (db *mongoDB) UpdateContract(contract core.Contract) error {
+	c, session, err := getMongoCollection("contracts")
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	selector := struct{ ID string }{ID: contract.ID}
+	err = c.Update(selector, contract)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete the contract.
+func DeleteContract(contractID string) error {
+	c, session, err := getMongoCollection("contracts")
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	selector := struct{ ID string }{ID: contractID}
+	err = c.Remove(selector)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/metaserver/mongoDB.go
+++ b/metaserver/mongoDB.go
@@ -47,8 +47,9 @@ func (db *mongoDB) FindRenterByID(renterID string) (*core.RenterInfo, error) {
 	}
 	defer session.Close()
 
+	selector := struct{ ID string }{ID: renterID}
 	var result core.RenterInfo
-	err = c.Find(nil).One(&result)
+	err = c.Find(selector).One(&result)
 	if err != nil {
 		return nil, err
 	}
@@ -131,8 +132,9 @@ func (db *mongoDB) FindProviderByID(providerID string) (*core.ProviderInfo, erro
 	}
 	defer session.Close()
 
+	selector := struct{ ID string }{ID: providerID}
 	var result core.ProviderInfo
-	err = c.Find(nil).One(&result)
+	err = c.Find(selector).One(&result)
 	if err != nil {
 		return nil, err
 	}

--- a/metaserver/mongoDB.go
+++ b/metaserver/mongoDB.go
@@ -177,7 +177,7 @@ func (db *mongoDB) UpdateProvider(provider core.ProviderInfo) error {
 
 // Delete the specified provider from the dtabase.
 func (db *mongoDB) DeleteProvider(providerID string) error {
-	c, session, err := getMongoCollection("renters")
+	c, session, err := getMongoCollection("providers")
 	if err != nil {
 		return err
 	}

--- a/metaserver/mongoDB.go
+++ b/metaserver/mongoDB.go
@@ -58,7 +58,7 @@ func (db *mongoDB) FindRenterByID(renterID string) (*core.RenterInfo, error) {
 }
 
 // Insert the provided renter into the database.
-func (db *mongoDB) InsertRenter(renter core.RenterInfo) error {
+func (db *mongoDB) InsertRenter(renter *core.RenterInfo) error {
 	c, session, err := getMongoCollection("renters")
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (db *mongoDB) InsertRenter(renter core.RenterInfo) error {
 }
 
 // Update the provided renter in the databse.
-func (db *mongoDB) UpdateRenter(renter core.RenterInfo) error {
+func (db *mongoDB) UpdateRenter(renter *core.RenterInfo) error {
 	c, session, err := getMongoCollection("renters")
 	if err != nil {
 		return err
@@ -143,7 +143,7 @@ func (db *mongoDB) FindProviderByID(providerID string) (*core.ProviderInfo, erro
 }
 
 // Insert the given provider into the database.
-func (db *mongoDB) InsertProvider(provider core.ProviderInfo) error {
+func (db *mongoDB) InsertProvider(provider *core.ProviderInfo) error {
 	c, session, err := getMongoCollection("providers")
 	if err != nil {
 		return err
@@ -159,7 +159,7 @@ func (db *mongoDB) InsertProvider(provider core.ProviderInfo) error {
 }
 
 // Update the given provider in the databse.
-func (db *mongoDB) UpdateProvider(provider core.ProviderInfo) error {
+func (db *mongoDB) UpdateProvider(provider *core.ProviderInfo) error {
 	c, session, err := getMongoCollection("providers")
 	if err != nil {
 		return err
@@ -318,7 +318,7 @@ func (db *mongoDB) FindFilesByOwner(renterID string) ([]core.File, error) {
 }
 
 // Insert the given file into the database.
-func (db *mongoDB) InsertFile(file core.File) error {
+func (db *mongoDB) InsertFile(file *core.File) error {
 	c, session, err := getMongoCollection("files")
 	if err != nil {
 		return err
@@ -334,7 +334,7 @@ func (db *mongoDB) InsertFile(file core.File) error {
 }
 
 // Update the given file in the database.
-func (db *mongoDB) UpdateFile(file core.File) error {
+func (db *mongoDB) UpdateFile(file *core.File) error {
 	c, session, err := getMongoCollection("files")
 	if err != nil {
 		return err
@@ -421,7 +421,7 @@ func (db *mongoDB) FindContractsByRenter(renterID string) ([]core.Contract, erro
 }
 
 // Insert the given contract into the database.
-func (db *mongoDB) InsertContract(contract core.Contract) error {
+func (db *mongoDB) InsertContract(contract *core.Contract) error {
 	c, session, err := getMongoCollection("contracts")
 	if err != nil {
 		return err
@@ -437,7 +437,7 @@ func (db *mongoDB) InsertContract(contract core.Contract) error {
 }
 
 // Update the given contract.
-func (db *mongoDB) UpdateContract(contract core.Contract) error {
+func (db *mongoDB) UpdateContract(contract *core.Contract) error {
 	c, session, err := getMongoCollection("contracts")
 	if err != nil {
 		return err

--- a/metaserver/mongoDB.go
+++ b/metaserver/mongoDB.go
@@ -217,8 +217,9 @@ func (db *mongoDB) FindFileByID(fileID string) (*core.File, error) {
 	}
 	defer session.Close()
 
+	selector := struct{ ID string }{ID: fileID}
 	var result core.File
-	err = c.Find(nil).One(&result)
+	err = c.Find(selector).One(&result)
 	if err != nil {
 		return nil, err
 	}

--- a/metaserver/mongoDB.go
+++ b/metaserver/mongoDB.go
@@ -248,15 +248,15 @@ func (db *mongoDB) FindFilesInRenterDirectory(renterID string) ([]core.File, err
 	// Retrieve files from collection.
 	files := session.DB(dbName).C("files")
 
-	selector := make([]struct{ ID string }, 0)
-	for _, file := range filesToFind {
-		selector = append(selector, struct{ ID string }{ID: file})
-	}
-
 	var foundFiles []core.File
-	err = files.Find(selector).All(&foundFiles)
-	if err != nil {
-		return nil, err
+	for _, item := range filesToFind {
+		selector := struct{ ID string }{ID: item}
+		var result core.File
+		err = files.Find(selector).One(&result)
+		if err != nil {
+			return nil, err
+		}
+		foundFiles = append(foundFiles, result)
 	}
 
 	return foundFiles, nil

--- a/metaserver/provider.go
+++ b/metaserver/provider.go
@@ -129,5 +129,6 @@ func (server *metaServer) putProviderHandler() http.HandlerFunc {
 		}
 		w.WriteHeader(http.StatusOK)
 		resp := postProviderResp{Provider: updatedProvider}
+		json.NewEncoder(w).Encode(resp)
 	})
 }

--- a/metaserver/provider.go
+++ b/metaserver/provider.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Retrieves the given provider's public RSA key.
-func (server *metaServer) getProviderPublicKey(providerID string) (string, error) {
+func (server *MetaServer) getProviderPublicKey(providerID string) (string, error) {
 	provider, err := server.db.FindProviderByID(providerID)
 	if err != nil {
 		return "", err
@@ -21,7 +21,7 @@ type getProvidersResp struct {
 	Providers []core.ProviderInfo `json:"providers"`
 }
 
-func (server *metaServer) getProvidersHandler() http.HandlerFunc {
+func (server *MetaServer) getProvidersHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		providers, err := server.db.FindAllProviders()
 		if err != nil {
@@ -42,7 +42,7 @@ type postProviderResp struct {
 	Error    string            `json:"error,omitempty"`
 }
 
-func (server *metaServer) postProviderHandler() http.HandlerFunc {
+func (server *MetaServer) postProviderHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var provider core.ProviderInfo
 		err := json.NewDecoder(r.Body).Decode(&provider)
@@ -84,7 +84,7 @@ func (server *metaServer) postProviderHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) getProviderHandler() http.HandlerFunc {
+func (server *MetaServer) getProviderHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		provider, err := server.db.FindProviderByID(params["id"])
@@ -98,7 +98,7 @@ func (server *metaServer) getProviderHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) putProviderHandler() http.HandlerFunc {
+func (server *MetaServer) putProviderHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		// Make sure provider exists.
@@ -146,7 +146,7 @@ func (server *metaServer) putProviderHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) deleteProviderHandler() http.HandlerFunc {
+func (server *MetaServer) deleteProviderHandler() http.HandlerFunc {
 	// BUG(kincaid): Validate that the person requesting the data is the specified renter.
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)

--- a/metaserver/provider.go
+++ b/metaserver/provider.go
@@ -71,7 +71,7 @@ func (server *metaServer) postProviderHandler() http.HandlerFunc {
 		}
 
 		provider.ID = fingerprintKey(provider.PublicKey)
-		err = server.db.InsertProvider(provider)
+		err = server.db.InsertProvider(&provider)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			resp := postProviderResp{Error: err.Error()}
@@ -132,7 +132,7 @@ func (server *metaServer) putProviderHandler() http.HandlerFunc {
 			return
 		}
 		// Put the new provider into the database.
-		err = server.db.UpdateProvider(updatedProvider)
+		err = server.db.UpdateProvider(&updatedProvider)
 		if err != nil {
 			server.logger.Println(err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/metaserver/renter.go
+++ b/metaserver/renter.go
@@ -92,10 +92,10 @@ func (server *metaServer) putRenterHandler() http.HandlerFunc {
 		}
 		// Attempt to decode the supplied renter.
 		var updatedRenter core.RenterInfo
-		err = json.NewDecoder(r.Body).Decode(updatedRenter)
+		err = json.NewDecoder(r.Body).Decode(&updatedRenter)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			resp := postRenterResp{Error: "could not parse body"}
+			resp := postRenterResp{Error: err.Error()}
 			json.NewEncoder(w).Encode(resp)
 			return
 		}

--- a/metaserver/renter.go
+++ b/metaserver/renter.go
@@ -130,3 +130,17 @@ func (server *metaServer) putRenterHandler() http.HandlerFunc {
 		json.NewEncoder(w).Encode(resp)
 	})
 }
+
+func (server *metaServer) deleteRenterHandler() http.HandlerFunc {
+	// BUG(kincaid): Validate that the person requesting the data is the specified renter.
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		err := server.db.DeleteRenter(params["id"])
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			server.logger.Println(err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/metaserver/renter.go
+++ b/metaserver/renter.go
@@ -112,7 +112,13 @@ func (server *metaServer) putRenterHandler() http.HandlerFunc {
 			resp := postRenterResp{Error: "must not change renter alias"}
 			json.NewEncoder(w).Encode(resp)
 			return
+		} else if updatedRenter.PublicKey != renter.PublicKey {
+			w.WriteHeader(http.StatusUnauthorized)
+			resp := postRenterResp{Error: "must not change renter public key"}
+			json.NewEncoder(w).Encode(resp)
+			return
 		}
+
 		// Put the new renter into the database.
 		err = server.db.UpdateRenter(updatedRenter)
 		if err != nil {

--- a/metaserver/renter.go
+++ b/metaserver/renter.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Retrieves the given renter's public RSA key.
-func (server *metaServer) getRenterPublicKey(renterID string) (string, error) {
+func (server *MetaServer) getRenterPublicKey(renterID string) (string, error) {
 	renter, err := server.db.FindRenterByID(renterID)
 	if err != nil {
 		return "", err
@@ -21,7 +21,7 @@ type postRenterResp struct {
 	Renter core.RenterInfo `json:"provider,omitempty"`
 }
 
-func (server *metaServer) postRenterHandler() http.HandlerFunc {
+func (server *MetaServer) postRenterHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var renter core.RenterInfo
 		err := json.NewDecoder(r.Body).Decode(&renter)
@@ -67,7 +67,7 @@ func (server *metaServer) postRenterHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) getRenterHandler() http.HandlerFunc {
+func (server *MetaServer) getRenterHandler() http.HandlerFunc {
 	// BUG(kincaid): Validate that the person requesting the data is the specified renter.
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
@@ -82,7 +82,7 @@ func (server *metaServer) getRenterHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) putRenterHandler() http.HandlerFunc {
+func (server *MetaServer) putRenterHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		// Make sure renter exists.
@@ -137,7 +137,7 @@ func (server *metaServer) putRenterHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) deleteRenterHandler() http.HandlerFunc {
+func (server *MetaServer) deleteRenterHandler() http.HandlerFunc {
 	// BUG(kincaid): Validate that the person requesting the data is the specified renter.
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)

--- a/metaserver/renter.go
+++ b/metaserver/renter.go
@@ -58,6 +58,7 @@ func (server *metaServer) postRenterHandler() http.HandlerFunc {
 			resp := postRenterResp{Error: err.Error()}
 			json.NewEncoder(w).Encode(resp)
 		}
+		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(renter)
 	})
 }

--- a/metaserver/renter.go
+++ b/metaserver/renter.go
@@ -56,7 +56,7 @@ func (server *metaServer) postRenterHandler() http.HandlerFunc {
 
 		renter.ID = fingerprintKey(renter.PublicKey)
 
-		err = server.db.InsertRenter(renter)
+		err = server.db.InsertRenter(&renter)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			resp := errorResp{Error: err.Error()}
@@ -123,7 +123,7 @@ func (server *metaServer) putRenterHandler() http.HandlerFunc {
 		}
 
 		// Put the new renter into the database.
-		err = server.db.UpdateRenter(updatedRenter)
+		err = server.db.UpdateRenter(&updatedRenter)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)

--- a/metaserver/rsa.go
+++ b/metaserver/rsa.go
@@ -1,6 +1,7 @@
 package metaserver
 
 import (
+	"bytes"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
@@ -31,4 +32,21 @@ func fingerprintKey(key string) string {
 	shaSum := sha256.Sum256([]byte(key))
 	fingerprint := hex.EncodeToString(shaSum[:])
 	return fingerprint
+}
+
+func getPublicKeyString(key *rsa.PublicKey) string {
+	keyBytes, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		panic(err)
+	}
+	keyBlock := &pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: keyBytes,
+	}
+	buf := bytes.NewBuffer(make([]byte, 0))
+	err = pem.Encode(buf, keyBlock)
+	if err != nil {
+		panic("could not encode PEM block")
+	}
+	return buf.String()
 }

--- a/metaserver/server.go
+++ b/metaserver/server.go
@@ -42,15 +42,16 @@ func InitServer(dataDirectory string, logger *log.Logger) http.Handler {
 	router.Handle("/renters/{id}", authMiddleware.Handler(server.getRenterHandler())).Methods("GET")
 	router.Handle("/renters/{id}", authMiddleware.Handler(server.putRenterHandler())).Methods("PUT")
 
-	router.Handle("/renters/{id}/files", authMiddleware.Handler(server.getFilesHandler())).Methods("GET")
-	router.Handle("/renters/{id}/files/{id}", authMiddleware.Handler(server.postFileHandler())).Methods("POST")
-	router.Handle("/renters/{id}/files/{id}", authMiddleware.Handler(server.getFileHandler())).Methods("GET")
-	router.Handle("/renters/{id}/files/{id}", authMiddleware.Handler(server.deleteFileHandler())).Methods("DELETE")
-	router.Handle("/renters/{id}/files/{id}/versions", authMiddleware.Handler(server.getFileVersionsHandler())).Methods("GET")
-	router.Handle("/renters/{id}/files/{id}/versions", authMiddleware.Handler(server.postFileVersionsHandler())).Methods("POST")
-	router.Handle("/renters/{id}/files/{id}/versions/{version}", authMiddleware.Handler(server.getFileVersionHandler())).Methods("GET")
-	router.Handle("/renters/{id}/files/{id}/versions/{version}", authMiddleware.Handler(server.putFileVersionHandler())).Methods("PUT")
-	router.Handle("/renters/{id}/files/{id}/versions/{version}", authMiddleware.Handler(server.deleteFileVersionHandler())).Methods("DELETE")
+	router.Handle("/renters/{renterID}/files", authMiddleware.Handler(server.getFilesHandler())).Methods("GET")
+	router.Handle("/renters/{renterID}/files", authMiddleware.Handler(server.postFileHandler())).Methods("POST")
+	router.Handle("/renters/{renterID}/files/{fileID}", authMiddleware.Handler(server.getFileHandler())).Methods("GET")
+	router.Handle("/renters/{renterID}/files/{fileID}", authMiddleware.Handler(server.putFileHandler())).Methods("PUT")
+	router.Handle("/renters/{renterID}/files/{fileID}", authMiddleware.Handler(server.deleteFileHandler())).Methods("DELETE")
+	router.Handle("/renters/{renterID}/files/{fileID}/versions", authMiddleware.Handler(server.getFileVersionsHandler())).Methods("GET")
+	router.Handle("/renters/{renterID}/files/{fileID}/versions", authMiddleware.Handler(server.postFileVersionHandler())).Methods("POST")
+	router.Handle("/renters/{renterID}/files/{fileID}/versions/{version}", authMiddleware.Handler(server.getFileVersionHandler())).Methods("GET")
+	router.Handle("/renters/{renterID}/files/{fileID}/versions/{version}", authMiddleware.Handler(server.putFileVersionHandler())).Methods("PUT")
+	router.Handle("/renters/{renterID}/files/{fileID}/versions/{version}", authMiddleware.Handler(server.deleteFileVersionHandler())).Methods("DELETE")
 
 	return router
 }

--- a/metaserver/server.go
+++ b/metaserver/server.go
@@ -53,6 +53,17 @@ func InitServer(dataDirectory string, logger *log.Logger) http.Handler {
 	router.Handle("/renters/{renterID}/files/{fileID}/versions/{version}", authMiddleware.Handler(server.getFileVersionHandler())).Methods("GET")
 	router.Handle("/renters/{renterID}/files/{fileID}/versions/{version}", authMiddleware.Handler(server.putFileVersionHandler())).Methods("PUT")
 	router.Handle("/renters/{renterID}/files/{fileID}/versions/{version}", authMiddleware.Handler(server.deleteFileVersionHandler())).Methods("DELETE")
+	router.Handle("/renters/{renterID}/files/{fileID}/permissions", authMiddleware.Handler(server.getFilePermissionsHandler())).Methods("GET")
+	router.Handle("/renters/{renterID}/files/{fileID}/permissions", authMiddleware.Handler(server.postFilePermissionHandler())).Methods("POST")
+	router.Handle("/renters/{renterID}/files/{fileID}/permissions/{sharedID}", authMiddleware.Handler(server.getFilePermissionHandler())).Methods("GET")
+	router.Handle("/renters/{renterID}/files/{fileID}/permissions/{sharedID}", authMiddleware.Handler(server.putFilePermissionHandler())).Methods("PUT")
+	router.Handle("/renters/{renterID}/files/{fileID}/permissions/{sharedID}", authMiddleware.Handler(server.deleteFilePermissionHandler())).Methods("DELETE")
+
+	router.Handle("/renters/{renterID}/shared", authMiddleware.Handler(server.getSharedFilesHandler())).Methods("GET")
+	router.Handle("/renters/{renterID}/shared/{fileID}", authMiddleware.Handler(server.getFileHandler())).Methods("GET")
+	router.Handle("/renters/{renterID}/shared/{fileID}", authMiddleware.Handler(server.deleteSharedFileHandler())).Methods("DELETE")
+	router.Handle("/renters/{renterID}/shared/{fileID}/versions", authMiddleware.Handler(server.getFileVersionsHandler())).Methods("GET")
+	router.Handle("/renters/{renterID}/shared/{fileID}/versions/{version}", authMiddleware.Handler(server.getFileVersionHandler())).Methods("GET")
 
 	return router
 }

--- a/metaserver/server.go
+++ b/metaserver/server.go
@@ -33,21 +33,24 @@ func InitServer(dataDirectory string, logger *log.Logger) http.Handler {
 	router.Handle("/auth/renter", server.authorizer.GetAuthChallengeHandler("renterID")).Methods("GET")
 	router.Handle("/auth/renter", server.authorizer.GetRespondAuthChallengeHandler("renterID", server.signingKey, server.getRenterPublicKey)).Methods("POST")
 
-	// BUG(kincaid): Add PUT method for providers.
 	router.Handle("/providers", server.getProvidersHandler()).Methods("GET")
 	router.Handle("/providers", server.postProviderHandler()).Methods("POST")
 	router.Handle("/providers/{id}", server.getProviderHandler()).Methods("GET")
+	router.Handle("/providers/{id}", authMiddleware.Handler(server.putProviderHandler())).Methods("PUT")
 
-	// BUG(kincaid): Add PUT method for renters.
 	router.Handle("/renters", server.postRenterHandler()).Methods("POST")
 	router.Handle("/renters/{id}", authMiddleware.Handler(server.getRenterHandler())).Methods("GET")
+	router.Handle("/renters/{id}", authMiddleware.Handler(server.putRenterHandler())).Methods("PUT")
 
-	// BUG(kincaid): Add PUT method for files.
-	router.Handle("/files/{id}", authMiddleware.Handler(server.postFileHandler())).Methods("POST")
-	router.Handle("/files/{id}", authMiddleware.Handler(server.getFileHandler())).Methods("GET")
-	router.Handle("/files/{id}", authMiddleware.Handler(server.deleteFileHandler())).Methods("DELETE")
-	router.Handle("/files/{id}/{version}", authMiddleware.Handler(server.getFileVersionHandler())).Methods("GET")
-	router.Handle("/files/{id}/{version}", authMiddleware.Handler(server.deleteFileVersionHandler())).Methods("DELETE")
+	router.Handle("/renters/{id}/files", authMiddleware.Handler(server.getFilesHandler())).Methods("GET")
+	router.Handle("/renters/{id}/files/{id}", authMiddleware.Handler(server.postFileHandler())).Methods("POST")
+	router.Handle("/renters/{id}/files/{id}", authMiddleware.Handler(server.getFileHandler())).Methods("GET")
+	router.Handle("/renters/{id}/files/{id}", authMiddleware.Handler(server.deleteFileHandler())).Methods("DELETE")
+	router.Handle("/renters/{id}/files/{id}/versions", authMiddleware.Handler(server.getFileVersionsHandler())).Methods("GET")
+	router.Handle("/renters/{id}/files/{id}/versions", authMiddleware.Handler(server.postFileVersionsHandler())).Methods("POST")
+	router.Handle("/renters/{id}/files/{id}/versions/{version}", authMiddleware.Handler(server.getFileVersionHandler())).Methods("GET")
+	router.Handle("/renters/{id}/files/{id}/versions/{version}", authMiddleware.Handler(server.putFileVersionHandler())).Methods("PUT")
+	router.Handle("/renters/{id}/files/{id}/versions/{version}", authMiddleware.Handler(server.deleteFileVersionHandler())).Methods("DELETE")
 
 	return router
 }

--- a/metaserver/server.go
+++ b/metaserver/server.go
@@ -85,6 +85,10 @@ type metaServer struct {
 	signingKey []byte
 }
 
+type errorResp struct {
+	Error string `json:"error"`
+}
+
 // ServeHTTP begins serving requests from the server's router.
 func (server *metaServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	server.logger.Println(r.Method, r.URL)

--- a/metaserver/server.go
+++ b/metaserver/server.go
@@ -36,6 +36,7 @@ func InitServer(dataDirectory string, logger *log.Logger) http.Handler {
 	router.Handle("/providers", server.postProviderHandler()).Methods("POST")
 	router.Handle("/providers/{id}", server.getProviderHandler()).Methods("GET")
 	router.Handle("/providers/{id}", authMiddleware.Handler(server.putProviderHandler())).Methods("PUT")
+	router.Handle("/providers/{id}", authMiddleware.Handler(server.deleteProviderHandler())).Methods("DELETE")
 
 	router.Handle("/renters", server.postRenterHandler()).Methods("POST")
 	router.Handle("/renters/{id}", authMiddleware.Handler(server.getRenterHandler())).Methods("GET")

--- a/metaserver/server.go
+++ b/metaserver/server.go
@@ -43,6 +43,12 @@ func InitServer(dataDirectory string, logger *log.Logger) http.Handler {
 	router.Handle("/renters/{id}", authMiddleware.Handler(server.putRenterHandler())).Methods("PUT")
 	router.Handle("/renters/{id}", authMiddleware.Handler(server.deleteRenterHandler())).Methods("DELETE")
 
+	router.Handle("/renters/{renterID}/contracts", authMiddleware.Handler(server.getContractsHandler())).Methods("GET")
+	router.Handle("/renters/{renterID}/contracts", authMiddleware.Handler(server.postContractHandler())).Methods("POST")
+	router.Handle("/renters/{renterID}/contracts/{contractID}", authMiddleware.Handler(server.getContractHandler())).Methods("GET")
+	router.Handle("/renters/{renterID}/contracts/{contractID}", authMiddleware.Handler(server.putContractHandler())).Methods("PUT")
+	router.Handle("/renters/{renterID}/contracts/{contractID}", authMiddleware.Handler(server.deleteContractHandler())).Methods("DELETE")
+
 	router.Handle("/renters/{renterID}/files", authMiddleware.Handler(server.getFilesHandler())).Methods("GET")
 	router.Handle("/renters/{renterID}/files", authMiddleware.Handler(server.postFileHandler())).Methods("POST")
 	router.Handle("/renters/{renterID}/files/{fileID}", authMiddleware.Handler(server.getFileHandler())).Methods("GET")

--- a/metaserver/server.go
+++ b/metaserver/server.go
@@ -40,6 +40,7 @@ func InitServer(dataDirectory string, logger *log.Logger) http.Handler {
 	router.Handle("/renters", server.postRenterHandler()).Methods("POST")
 	router.Handle("/renters/{id}", authMiddleware.Handler(server.getRenterHandler())).Methods("GET")
 	router.Handle("/renters/{id}", authMiddleware.Handler(server.putRenterHandler())).Methods("PUT")
+	router.Handle("/renters/{id}", authMiddleware.Handler(server.deleteRenterHandler())).Methods("DELETE")
 
 	router.Handle("/renters/{renterID}/files", authMiddleware.Handler(server.getFilesHandler())).Methods("GET")
 	router.Handle("/renters/{renterID}/files", authMiddleware.Handler(server.postFileHandler())).Methods("POST")

--- a/metaserver/server.go
+++ b/metaserver/server.go
@@ -3,7 +3,6 @@ package metaserver
 import (
 	"log"
 	"net/http"
-	"path"
 	"skybin/authorization"
 	"skybin/core"
 
@@ -14,7 +13,7 @@ import (
 func InitServer(dataDirectory string, logger *log.Logger) http.Handler {
 	router := mux.NewRouter()
 
-	db := newJsonDB(path.Join(dataDirectory, "metaDB.json"))
+	db := mongoDB{}
 
 	server := &metaServer{
 		dataDir:    dataDirectory,

--- a/metaserver/shared.go
+++ b/metaserver/shared.go
@@ -1,0 +1,62 @@
+package metaserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func (server *metaServer) getSharedFilesHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		// Make sure the specified renter actually exists.
+		renter, err := server.db.FindRenterByID(params["renterID"])
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			resp := fileResp{Error: err.Error()}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		// Retrieve the renter's shared files.
+		files, err := server.db.FindFilesSharedWithRenter(renter.ID)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			server.logger.Println(err)
+			return
+		}
+		json.NewEncoder(w).Encode(files)
+	})
+}
+
+func (server *metaServer) deleteSharedFileHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		// Remove the file from the renter's directory.
+		renter, err := server.db.FindRenterByID(params["renterID"])
+		if err != nil {
+			server.logger.Println(err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		removeIndex := -1
+		for i, fileID := range renter.Shared {
+			if fileID == params["fileID"] {
+				removeIndex = i
+			}
+		}
+		if removeIndex == -1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			server.logger.Println("could not find file in renter's shared directory")
+			return
+		}
+		renter.Shared = append(renter.Shared[:removeIndex], renter.Shared[removeIndex+1:]...)
+		err = server.db.UpdateRenter(*renter)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			server.logger.Println(err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/metaserver/shared.go
+++ b/metaserver/shared.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (server *metaServer) getSharedFilesHandler() http.HandlerFunc {
+func (server *MetaServer) getSharedFilesHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		// Make sure the specified renter actually exists.
@@ -31,7 +31,7 @@ func (server *metaServer) getSharedFilesHandler() http.HandlerFunc {
 	})
 }
 
-func (server *metaServer) deleteSharedFileHandler() http.HandlerFunc {
+func (server *MetaServer) deleteSharedFileHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		// Remove the file from the renter's directory.

--- a/metaserver/shared.go
+++ b/metaserver/shared.go
@@ -23,6 +23,8 @@ func (server *metaServer) getSharedFilesHandler() http.HandlerFunc {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
+			resp := errorResp{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 		json.NewEncoder(w).Encode(files)
@@ -35,8 +37,9 @@ func (server *metaServer) deleteSharedFileHandler() http.HandlerFunc {
 		// Remove the file from the renter's directory.
 		renter, err := server.db.FindRenterByID(params["renterID"])
 		if err != nil {
-			server.logger.Println(err)
-			w.WriteHeader(http.StatusInternalServerError)
+			w.WriteHeader(http.StatusNotFound)
+			resp := errorResp{Error: "could not find renter"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 		removeIndex := -1
@@ -48,6 +51,8 @@ func (server *metaServer) deleteSharedFileHandler() http.HandlerFunc {
 		if removeIndex == -1 {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println("could not find file in renter's shared directory")
+			resp := errorResp{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 		renter.Shared = append(renter.Shared[:removeIndex], renter.Shared[removeIndex+1:]...)
@@ -55,6 +60,8 @@ func (server *metaServer) deleteSharedFileHandler() http.HandlerFunc {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)
+			resp := errorResp{Error: "internal server error"}
+			json.NewEncoder(w).Encode(resp)
 			return
 		}
 		w.WriteHeader(http.StatusOK)

--- a/metaserver/shared.go
+++ b/metaserver/shared.go
@@ -56,7 +56,7 @@ func (server *metaServer) deleteSharedFileHandler() http.HandlerFunc {
 			return
 		}
 		renter.Shared = append(renter.Shared[:removeIndex], renter.Shared[removeIndex+1:]...)
-		err = server.db.UpdateRenter(*renter)
+		err = server.db.UpdateRenter(renter)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			server.logger.Println(err)

--- a/renter/renter.go
+++ b/renter/renter.go
@@ -18,6 +18,7 @@ import (
 
 type Config struct {
 	RenterId       string `json:"renterId"`
+	RenterAlias    string `json"renterAlias"`
 	ApiAddr        string `json:"apiAddress"`
 	MetaAddr       string `json:"metaServerAddress"`
 	PrivateKeyFile string `json:"privateKeyFile"`

--- a/renter/upload.go
+++ b/renter/upload.go
@@ -117,13 +117,17 @@ func (r *Renter) Upload(srcPath string, destPath string, shouldOverwrite bool) (
 		ID:         fileId,
 		Name:       destPath,
 		IsDir:      false,
-		Size:       finfo.Size(),
-		UploadSize: uploadSize,
-		ModTime:    finfo.ModTime(),
 		AccessList: []core.Permission{},
 		AesKey:     string(aesKeyEncrypted),
 		AesIV:      string(aesIVEncrypted),
-		Blocks:     blocks,
+		Versions: []core.Version{
+			core.Version{
+				Size:       finfo.Size(),
+				UploadSize: uploadSize,
+				Blocks:     blocks,
+				ModTime:    finfo.ModTime(),
+			},
+		},
 	}
 	err = r.saveFile(file)
 	if err != nil {


### PR DESCRIPTION
This PR adds a MongoDB backend for the metadata server and an implementation of our V2 metadata API endpoints. It also patches the renter to use the new API in a limited manner (it only downloads the latest version of files, removes all versions of files, and uploads new files with one version). Finally, it comes with a suite of tests for the metaserver, and a couple scripts for easily setting up and clearing the database.

Things to note:
- The code in this PR is pretty rough, but it's functional. I plan on refactoring it, but want to get it merged ASAP so we can all work with the same data models and can raise issues with endpoint behavior.
- As I stated before, I only patched the renter so it would keep working with the API. @AlexSteele I was planning on working with you to nail that down more.
- There are no new authentication features. I'll add those in the coming weeks.
- To run the metaserver, you now have to have MongoDB installed. If you're running on Mac, you can follow the instructions [here](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/). After you install mongo locally, you shoudn't really need to perform any configuration on the database itself. Also, be sure to run the `setup_db.js` script before launching the metaserver, and the `clear_db.js` script to clear out the database. You can run each script by typing `mongo [script path]`. 