### PR TITLE
Integrate renter/metaserver. Bug fixes.

### DIFF
--- a/cmd/renter.go
+++ b/cmd/renter.go
@@ -160,12 +160,11 @@ func runRenterInit(args ...string) {
 	}
 
 	// Create renter config
-	config := renter.Config{
-		PrivateKeyFile: privateKeyPath,
-		PublicKeyFile:  publicKeyPath,
-		ApiAddr:        core.DefaultRenterAddr,
-		MetaAddr:       core.DefaultMetaAddr,
-	}
+	config := renter.DefaultConfig()
+	config.PrivateKeyFile = privateKeyPath
+	config.PublicKeyFile = publicKeyPath
+	config.ApiAddr = core.DefaultRenterAddr
+	config.MetaAddr = core.DefaultMetaAddr
 	if len(*apiAddrFlag) > 0 {
 		config.ApiAddr = *apiAddrFlag
 	}

--- a/cmd/renter.go
+++ b/cmd/renter.go
@@ -208,7 +208,6 @@ func runRenterInit(args ...string) {
 		config.RenterId = updatedInfo.ID
 		config.Alias = *aliasFlag
 	}
-	config.IsRegistered = true
 
 	err = util.SaveJson(path.Join(homeDir, "config.json"), &config)
 	if err != nil {
@@ -252,6 +251,7 @@ func runRenterDaemon(args ...string) {
 	defer logfile.Close()
 	logger := log.New(logfile, "", log.LstdFlags)
 
+	r.SetLogger(logger)
 	server := renter.NewServer(r, logger)
 
 	log.Println("starting renter server at", addr)

--- a/core/contract.go
+++ b/core/contract.go
@@ -7,23 +7,28 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"time"
 )
 
 // A contract without the signature fields,
 // with other fields sorted by name.
 type contractTerms struct {
-	ID           string `json:"id"`
-	ProviderId   string `json:"providerId"`
-	RenterId     string `json:"renterId"`
-	StorageSpace int64  `json:"storageSpace"`
+	EndDate      time.Time `json:"endDate"`
+	ID           string    `json:"id"`
+	ProviderId   string    `json:"providerId"`
+	RenterId     string    `json:"renterId"`
+	StartDate    time.Time `json:"startDate"`
+	StorageSpace int64     `json:"storageSpace"`
 }
 
 func makeTerms(c *Contract) contractTerms {
 	return contractTerms{
+		EndDate:      c.EndDate,
 		ID:           c.ID,
 		ProviderId:   c.ProviderId,
 		RenterId:     c.RenterId,
 		StorageSpace: c.StorageSpace,
+		StartDate:    c.StartDate,
 	}
 }
 

--- a/core/core.go
+++ b/core/core.go
@@ -5,10 +5,10 @@ import (
 )
 
 const (
-	DefaultMetaAddr     = "127.0.0.1:8001"
-	DefaultRenterAddr   = "127.0.0.1:8002"
+	DefaultMetaAddr           = "127.0.0.1:8001"
+	DefaultRenterAddr         = "127.0.0.1:8002"
 	DefaultPublicProviderAddr = ":8003"
-	DefaultLocalProviderAddr = "127.0.0.1:8004"
+	DefaultLocalProviderAddr  = "127.0.0.1:8004"
 )
 
 type ProviderInfo struct {
@@ -28,12 +28,14 @@ type RenterInfo struct {
 }
 
 type Contract struct {
-	ID                string `json:"contractId"`
-	RenterId          string `json:"renterId"`
-	ProviderId        string `json:"providerId"`
-	StorageSpace      int64  `json:"storageSpace"`
-	RenterSignature   string `json:"renterSignature"`
-	ProviderSignature string `json:"providerSignature"`
+	ID                string    `json:"contractId"`
+	RenterId          string    `json:"renterId"`
+	ProviderId        string    `json:"providerId"`
+	StorageSpace      int64     `json:"storageSpace"`
+	StartDate         time.Time `json:"startDate"`
+	EndDate           time.Time `json:"endDate"`
+	RenterSignature   string    `json:"renterSignature"`
+	ProviderSignature string    `json:"providerSignature"`
 }
 
 type BlockLocation struct {

--- a/core/core.go
+++ b/core/core.go
@@ -85,6 +85,7 @@ type Version struct {
 	Num             int       `json:"num"`
 	Size            int64     `json:"size"`
 	ModTime         time.Time `json:"modTime"`
+	UploadTime      time.Time `json:"uploadTime"`
 	UploadSize      int64     `json:"uploadSize"`
 	PaddingBytes    int64     `json:"paddingBytes"`
 	NumDataBlocks   int       `json:"numDataBlocks"`

--- a/core/core.go
+++ b/core/core.go
@@ -19,17 +19,6 @@ type ProviderInfo struct {
 	StorageRate int64  `json:"storageRate"`
 }
 
-// Alternative approach from metadata server
-// type StorageRate struct {
-// 	// The fee “Fee” in currency “Currency” for storing
-// 	// “StorageAmount” bytes for “PeriodSec” seconds
-// 	Currency       string `json:"currency"`
-// 	StorageAmount  int64  `json:"storageAmount"`
-// 	Fee            string `json:"fee"`
-// 	PeriodSec      string `json:"periodSec"`
-// 	PaymentAddress string `json:"paymentAddress"`
-// }
-
 type RenterInfo struct {
 	ID        string   `json:"id"`
 	Alias     string   `json:"alias"`
@@ -66,8 +55,8 @@ type Block struct {
 	// sha256 hash of the block
 	Sha256Hash string `json:"sha256hash"`
 
-	// Locations of providers where the block is stored
-	Locations []BlockLocation `json:"locations"`
+	// Location of the provider where the block is stored
+	Location BlockLocation `json:"location"`
 }
 
 // Permission provides access to a file to a non-owning user

--- a/integration/file_recovery_test.py
+++ b/integration/file_recovery_test.py
@@ -42,7 +42,7 @@ def file_recovery_test(ctxt):
     renter_id = ctxt.renter.get_info()['id']
     for block in blocks_to_remove:
         ctxt.log('removing block {}'.format(block['id']))
-        location = block['locations'][0]
+        location = block['location']
         addr = location['address']
         pvdr = next(p for p in ctxt.providers if p.address  == addr)
         block_location = os.path.join(pvdr.homedir, 'blocks', renter_id, block['id'])

--- a/integration/folder_download_test.py
+++ b/integration/folder_download_test.py
@@ -1,0 +1,63 @@
+
+"""
+Test for downloading a folder tree.
+"""
+
+import argparse
+import os.path
+from test_framework import setup_test
+
+DEFAULT_FILE_SIZE = 1024 * 1024
+
+def folder_download_test(ctxt):
+    input_path = ctxt.create_test_file(size=DEFAULT_FILE_SIZE)
+
+    # Reserve a gigabyte of space.
+    ctxt.renter.reserve_space(int(1e9))
+
+    # Create folder hierarchy
+    root_folder = ctxt.renter.create_folder('folder')
+    ctxt.renter.create_folder('folder/folder1')
+    ctxt.renter.create_folder('folder/folder1/folder2')
+    ctxt.renter.upload_file(input_path, 'folder/file1.txt')
+    ctxt.renter.upload_file(input_path, 'folder/folder1/file1.txt')
+    ctxt.renter.upload_file(input_path, 'folder/folder1/folder2/file1.txt')
+
+    # Create additional files which should not be downloaded
+    ctxt.renter.create_folder('other_folder')
+    ctxt.renter.upload_file(input_path, 'other_file.txt')
+
+    # Download the folder hierarchy
+    output_path = ctxt.create_output_path()
+    ctxt.renter.download_file(root_folder['id'], output_path)
+
+    # Check that the proper file tree was created
+    file_names = [
+        output_path,
+        os.path.join(output_path, 'folder1'),
+        os.path.join(output_path, 'folder1', 'folder2'),
+        os.path.join(output_path, 'file1.txt'),
+        os.path.join(output_path, 'folder1', 'file1.txt'),
+        os.path.join(output_path, 'folder1', 'folder2', 'file1.txt'),
+    ]
+    for name in file_names:
+        ctxt.assert_true(os.path.exists(name), 'failed to download {}'.format(name))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--num_providers', type=int, default=1,
+                        help='number of providers to run')
+    args = parser.parse_args()
+    ctxt = setup_test(
+        num_providers=args.num_providers,
+    )
+    try:
+        ctxt.log('folder download test')
+        folder_download_test(ctxt)
+        ctxt.log('ok')
+    finally:
+        ctxt.teardown()
+
+if __name__ == '__main__':
+    main()

--- a/integration/folder_upload_test.py
+++ b/integration/folder_upload_test.py
@@ -1,0 +1,62 @@
+
+"""
+Test for uploading a folder hierarchy.
+"""
+
+import argparse
+import os
+import random
+from test_framework import setup_test, create_file_name, create_test_file
+
+def folder_upload_test(ctxt):
+
+    # Create folder hierarchy
+    base_folder = ctxt.test_file_dir + '/folder' + str(random.randint(1, 64))
+    folders = [
+        '/folder2',
+        '/folder2/folder3',
+    ]
+    files = [
+        '/file1.txt',
+        '/file2.txt',
+        '/folder2/file1.txt',
+        '/folder2/folder3/file1.txt',
+    ]
+    os.makedirs(base_folder)
+    for folder_name in folders:
+        os.makedirs(base_folder + folder_name)
+    for file_name in files:
+        create_test_file(base_folder + file_name, 1024 * 1024)
+
+    # Upload
+    ctxt.renter.reserve_space(int(1e9))
+    dest_folder = 'folder'
+    root_folder = ctxt.renter.upload_file(base_folder, dest_folder)
+
+    # Check file listing
+    all_paths = folders + files
+    all_paths = [dest_folder + path for path in all_paths]
+    all_paths.append(dest_folder)
+    all_files = ctxt.renter.list_files()['files']
+    all_file_names = [f['name'] for f in all_files]
+    for path in all_paths:
+        ctxt.assert_true(set(all_file_names) == set(all_paths), 'folder hierarchies do not match')
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--num_providers', type=int, default=1,
+                        help='number of providers to run')
+    args = parser.parse_args()
+    ctxt = setup_test(
+        num_providers=args.num_providers,
+        remove_test_files=False,
+    )
+    try:
+        ctxt.log('folder upload test')
+        folder_upload_test(ctxt)
+        ctxt.log('ok')
+    finally:
+        ctxt.teardown()
+
+if __name__ == '__main__':
+    main()

--- a/integration/renter.py
+++ b/integration/renter.py
@@ -19,21 +19,27 @@ class RenterAPI:
         if resp.status_code != 201:
             raise ValueError(resp.content.decode('utf-8'))
 
-    def upload_file(self, source, dest):
-        resp = requests.post(self.base_url + '/files/upload', json={
+    def upload_file(self, source, dest, should_overwrite=None):
+        args = {
             'sourcePath': source,
-            'destPath': dest
-        })
+            'destPath': dest,
+        }
+        if should_overwrite != None:
+            args['shouldOverwrite'] = should_overwrite
+        resp = requests.post(self.base_url + '/files/upload', json=args)
         if resp.status_code != 201:
             raise ValueError(resp.content.decode('utf-8'))
         return json.loads(resp.content)
 
-    def download_file(self, file_id, destination):
+    def download_file(self, file_id, destination, version_num=None):
         url = self.base_url + '/files/download'
-        resp = requests.post(url, json={
+        args = {
             'fileId': file_id,
             'destPath': destination,
-        })
+        }
+        if version_num != None:
+            args['versionNum'] = version_num
+        resp = requests.post(url, json=args)
         if resp.status_code != 201:
             raise ValueError(resp.content.decode('utf-8'))
 
@@ -65,9 +71,12 @@ class RenterAPI:
             raise ValueError(str(resp.status_code) + ' ' + resp.content.decode('utf-8'))
         return json.loads(resp.content)
 
-    def remove_file(self, file_id):
+    def remove_file(self, file_id, version_num=None):
         url = '{}/files/remove'.format(self.base_url)
-        resp = requests.post(url, json={'fileID': file_id})
+        args = {'fileID': file_id}
+        if version_num != None:
+            args['versionNum'] = version_num
+        resp = requests.post(url, json=args)
         if resp.status_code != 200:
             raise ValueError(resp.content.decode('utf-8'))
 

--- a/integration/share_file_test.py
+++ b/integration/share_file_test.py
@@ -38,8 +38,6 @@ def main():
     ctxt = setup_test(
         num_providers=args.num_providers,
         num_additional_renters=1,
-        remove_test_files=False,
-        teardown_db=False
     )
     try:
         share_test(ctxt, file_size=args.file_size)

--- a/integration/test_framework.py
+++ b/integration/test_framework.py
@@ -6,6 +6,7 @@ Framework and helpers for running integration tests.
 from renter import RenterAPI
 import json
 import os
+import os.path
 import sys
 import random
 import shutil
@@ -15,10 +16,10 @@ import time
 import sys
 
 # Default location for skybin repos
-DEFAULT_REPOS_DIR = './repos'
+DEFAULT_REPOS_DIR = os.path.abspath('./repos')
 
 # Default location for test files
-DEFAULT_TEST_FILE_DIR = './files'
+DEFAULT_TEST_FILE_DIR = os.path.abspath('./files')
 
 # Whether test logging is enabled by default
 LOG_ENABLED = True
@@ -48,19 +49,17 @@ def create_file_name():
     filename = ''.join([random.choice(prefixes), unique_chars, random.choice(suffixes)])
     return filename
 
-def create_test_file(file_dir, size):
+def create_test_file(location, size):
     """Create a test file
 
     Args:
-      file_dir: directory to place file
+      location: name for the file
       size: size of the file, in bytes
 
     Returns:
       the full name of the created test file
     """
-    filename = create_file_name()
-    filepath = '{}/{}'.format(file_dir, filename)
-    with open(filepath, 'wb+') as f:
+    with open(location, 'wb+') as f:
         stride_len = 128 * 1024
         strides = size // stride_len
         for _ in range(strides):
@@ -70,7 +69,7 @@ def create_test_file(file_dir, size):
         if rem != 0:
             buf = os.urandom(rem)
             f.write(buf)
-    return filepath
+    return location
 
 def check_service_startup(process):
     """Check that a service process started without error."""
@@ -185,8 +184,10 @@ class TestContext:
 
     def create_test_file(self, size):
         """Create a test file. Returns the file's name."""
-        file_name = create_test_file(self.test_file_dir, size)
-        self._test_files.append(file_name)
+        file_name = create_file_name()
+        file_path = '{}/{}'.format(self.test_file_dir, file_name)
+        create_test_file(file_path, size)
+        self._test_files.append(file_path)
         return file_name
 
     def create_output_path(self):

--- a/integration/test_framework.py
+++ b/integration/test_framework.py
@@ -127,11 +127,11 @@ class RenterService(Service):
     def reserve_space(self, amount):
         return self._api.reserve_space(amount)
 
-    def upload_file(self, source, dest):
-        return self._api.upload_file(source, dest)
+    def upload_file(self, source, dest, should_overwrite=None):
+        return self._api.upload_file(source, dest, should_overwrite=should_overwrite)
 
-    def download_file(self, file_id, destination):
-        return self._api.download_file(file_id, destination)
+    def download_file(self, file_id, destination, version_num=None):
+        return self._api.download_file(file_id, destination, version_num=version_num)
 
     def rename_file(self, file_id, name):
         return self._api.rename_file(file_id, name)
@@ -142,8 +142,8 @@ class RenterService(Service):
     def share_file(self, file_id, user_id):
         return self._api.share_file(file_id, user_id)
 
-    def remove_file(self, file_id):
-        return self._api.remove_file(file_id)
+    def remove_file(self, file_id, version_num=None):
+        return self._api.remove_file(file_id, version_num=version_num)
 
     def list_files(self):
         return self._api.list_files()
@@ -188,7 +188,7 @@ class TestContext:
         file_path = '{}/{}'.format(self.test_file_dir, file_name)
         create_test_file(file_path, size)
         self._test_files.append(file_path)
-        return file_name
+        return file_path
 
     def create_output_path(self):
         """Get an output path that a file can be downloaded to."""

--- a/integration/version_test.py
+++ b/integration/version_test.py
@@ -1,0 +1,85 @@
+
+"""
+Test for uploading, downloading, and removing versions of a file with the same name.
+"""
+
+import argparse
+import filecmp
+from test_framework import setup_test
+
+def version_test(ctxt):
+    file1 = ctxt.create_test_file(size=1000)
+    file2 = ctxt.create_test_file(size=1000)
+
+    ctxt.renter.reserve_space(2 * int(1e9))
+
+    dest_path = 'destination.txt'
+    f = ctxt.renter.upload_file(file1, dest_path)
+
+    # Upload a copy with overwrite set
+    f = ctxt.renter.upload_file(file1, dest_path, should_overwrite=True)
+    ctxt.assert_true(len(f['versions']) == 1, 'failed to overwrite old version')
+
+    # Upload the second file with the same destination and without overwrite set
+    f = ctxt.renter.upload_file(file2, dest_path)
+    ctxt.assert_true(len(f['versions']) == 2, 'failed to create new version')
+
+    all_files = ctxt.renter.list_files()['files']
+    ctxt.assert_true(len(all_files) == 1, 'created new file unexpectedly')
+
+    # Download should by default download the latest version
+    output_path = ctxt.create_output_path()
+    ctxt.renter.download_file(f['id'], output_path)
+    is_match = filecmp.cmp(file2, output_path)
+    ctxt.assert_true(is_match, 'downloaded incorrect version of file')
+
+    # Download the first version
+    first_version = f['versions'][0]['num']
+    ctxt.renter.download_file(f['id'], output_path, version_num=first_version)
+    is_match = filecmp.cmp(file1, output_path)
+    ctxt.assert_true(is_match, 'downloaded incorrect version of file')
+
+    # Remove the first version
+    ctxt.renter.remove_file(f['id'], version_num=first_version)
+    all_files = ctxt.renter.list_files()['files']
+    ctxt.assert_true(len(all_files) == 1, 'removing version removed entire file')
+
+    # Attempting to remove the final version should fail
+    f = all_files[0]
+    try:
+        ctxt.renter.remove_file(f['id'], version_num=f['versions'][0]['versionNum'])
+        ctxt.assert_true(False, 'removing final file version should not succeed')
+    except:
+        pass
+
+    # Removing the file altogether should succeed
+    ctxt.renter.remove_file(f['id'])
+
+    # Finally, uploading five new copies should create a file with five versions
+    for _ in range(5):
+        f = ctxt.renter.upload_file(file1, dest_path)
+
+    ctxt.assert_true(len(f['versions']) == 5, 'file has too few versions')
+
+    # ...And deleting the file should delete all versions
+    ctxt.renter.remove_file(f['id'])
+    all_files = ctxt.renter.list_files()['files']
+    ctxt.assert_true(len(all_files) == 0, 'renter should not have any files')
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--num_providers', type=int, default=1,
+                        help='number of providers to run')
+    args = parser.parse_args()
+    ctxt = setup_test(
+        num_providers=args.num_providers,
+    )
+    try:
+        ctxt.log('version test')
+        version_test(ctxt)
+        ctxt.log('ok')
+    finally:
+        ctxt.teardown()
+
+if __name__ == '__main__':
+    main()

--- a/provider/blocks.go
+++ b/provider/blocks.go
@@ -10,110 +10,109 @@ import (
 	"time"
 )
 
-func (server *providerServer) postBlockHandler() http.HandlerFunc {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// confirm that the request has the blockid field
-		blockquery, exists := r.URL.Query()["blockID"]
-		if !exists {
-			server.writeResp(w, http.StatusBadRequest, errorResp{Error: "No block given"})
-			return
-		}
-		blockID := blockquery[0]
+func (server *providerServer) postBlock(w http.ResponseWriter, r *http.Request) {
 
-		// TODO: Replace this with authorization token
-		renterquery, exists := r.URL.Query()["renterID"]
-		if !exists {
-			server.writeResp(w, http.StatusBadRequest, errorResp{Error: "No renter ID given"})
-			return
-		}
-		renterID := renterquery[0]
+	// confirm that the request has the blockid field
+	blockquery, exists := r.URL.Query()["blockID"]
+	if !exists {
+		server.writeResp(w, http.StatusBadRequest, errorResp{Error: "No block given"})
+		return
+	}
+	blockID := blockquery[0]
 
-		claims, err := util.GetTokenClaimsFromRequest(r)
+	// TODO: Replace this with authorization token
+	renterquery, exists := r.URL.Query()["renterID"]
+	if !exists {
+		server.writeResp(w, http.StatusBadRequest, errorResp{Error: "No renter ID given"})
+		return
+	}
+	renterID := renterquery[0]
+
+	claims, err := util.GetTokenClaimsFromRequest(r)
+	if err != nil {
+		server.writeResp(w, http.StatusInternalServerError,
+			errorResp{Error: "Failure parsing authentication token"})
+		return
+	}
+
+	// Check to confirm that the authentication token matches that of the querying renter
+	if claimID, present := claims["renterID"]; !present || claimID.(string) != renterID {
+		server.writeResp(w, http.StatusForbidden, errorResp{Error: "Authentication token does not match renterID"})
+		return
+	}
+
+	renter, exists := server.provider.renters[renterID]
+	if !exists {
+		server.writeResp(w, http.StatusBadRequest,
+			errorResp{Error: "Insufficient space: You have no storage reserved."})
+		return
+	}
+	spaceAvail := renter.StorageReserved - renter.StorageUsed
+
+	// first check block size using the http header
+	if r.ContentLength > spaceAvail {
+		msg := fmt.Sprintf("Block of size %d exceeds available storage %d", r.ContentLength, spaceAvail)
+		server.writeResp(w, http.StatusBadRequest, errorResp{Error: msg})
+		return
+	}
+
+	// create directory for renter's blocks if necessary
+	renterDir := path.Join(server.provider.Homedir, "blocks", renterID)
+	if _, err := os.Stat(renterDir); os.IsNotExist(err) {
+		err := os.MkdirAll(renterDir, 0700)
 		if err != nil {
-			server.writeResp(w, http.StatusInternalServerError,
-				errorResp{Error: "Failure parsing authentication token"})
-			return
-		}
-
-		// Check to confirm that the authentication token matches that of the querying renter
-		if claimID, present := claims["renterID"]; !present || claimID.(string) != renterID {
-			server.writeResp(w, http.StatusForbidden, errorResp{Error: "Authentication token does not match renterID"})
-			return
-		}
-
-		renter, exists := server.provider.renters[renterID]
-		if !exists {
-			server.writeResp(w, http.StatusBadRequest,
-				errorResp{Error: "Insufficient space: You have no storage reserved."})
-			return
-		}
-		spaceAvail := renter.StorageReserved - renter.StorageUsed
-
-		// first check block size using the http header
-		if r.ContentLength > spaceAvail {
-			msg := fmt.Sprintf("Block of size %d exceeds available storage %d", r.ContentLength, spaceAvail)
-			server.writeResp(w, http.StatusBadRequest, errorResp{Error: msg})
-			return
-		}
-
-		// create directory for renter's blocks if necessary
-		renterDir := path.Join(server.provider.Homedir, "blocks", renterID)
-		if _, err := os.Stat(renterDir); os.IsNotExist(err) {
-			err := os.MkdirAll(renterDir, 0700)
-			if err != nil {
-				server.logger.Println(err)
-				server.writeResp(w, http.StatusInternalServerError,
-					errorResp{Error: "Unable to save block"})
-				return
-			}
-		}
-
-		// create file
-		path := path.Join(renterDir, blockID)
-		f, err := os.Create(path)
-		if err != nil {
-			server.logger.Println("Unable to create block file. Error: ", err)
+			server.logger.Println(err)
 			server.writeResp(w, http.StatusInternalServerError,
 				errorResp{Error: "Unable to save block"})
 			return
 		}
-		defer f.Close()
+	}
 
-		n, err := io.Copy(f, r.Body)
-		if err != nil {
-			server.logger.Println("Unable to write block. Error: ", err)
-			server.writeResp(w, http.StatusInternalServerError,
-				errorResp{Error: "Unable to save block"})
-			return
-		}
+	// create file
+	path := path.Join(renterDir, blockID)
+	f, err := os.Create(path)
+	if err != nil {
+		server.logger.Println("Unable to create block file. Error: ", err)
+		server.writeResp(w, http.StatusInternalServerError,
+			errorResp{Error: "Unable to save block"})
+		return
+	}
+	defer f.Close()
 
-		// Verify that received file is the correct size
-		if n > spaceAvail {
-			os.Remove(path)
-			msg := fmt.Sprintf("Block of size %d, exceeds available storage %d", n, spaceAvail)
-			server.logger.Println(msg)
-			server.writeResp(w, http.StatusInsufficientStorage, errorResp{Error: msg})
-			return
-		}
+	n, err := io.Copy(f, r.Body)
+	if err != nil {
+		server.logger.Println("Unable to write block. Error: ", err)
+		server.writeResp(w, http.StatusInternalServerError,
+			errorResp{Error: "Unable to save block"})
+		return
+	}
 
-		// Update stats
-		server.provider.stats.StorageUsed += n
-		renter.StorageUsed += n
-		renter.Blocks = append(renter.Blocks, &BlockInfo{BlockId: blockID, Size: n})
+	// Verify that received file is the correct size
+	if n > spaceAvail {
+		os.Remove(path)
+		msg := fmt.Sprintf("Block of size %d, exceeds available storage %d", n, spaceAvail)
+		server.logger.Println(msg)
+		server.writeResp(w, http.StatusInsufficientStorage, errorResp{Error: msg})
+		return
+	}
 
-		activity := Activity{
-			RequestType: postBlockType,
-			BlockId:     blockID,
-			RenterId:    renterID,
-			TimeStamp:   time.Now(),
-		}
-		server.provider.addActivity(activity)
-		err = server.provider.saveSnapshot()
-		if err != nil {
-			server.logger.Println("Unable to save snapshot. Error:", err)
-		}
-		server.writeResp(w, http.StatusCreated, &errorResp{})
-	})
+	// Update stats
+	server.provider.stats.StorageUsed += n
+	renter.StorageUsed += n
+	renter.Blocks = append(renter.Blocks, &BlockInfo{BlockId: blockID, Size: n})
+
+	activity := Activity{
+		RequestType: postBlockType,
+		BlockId:     blockID,
+		RenterId:    renterID,
+		TimeStamp:   time.Now(),
+	}
+	server.provider.addActivity(activity)
+	err = server.provider.saveSnapshot()
+	if err != nil {
+		server.logger.Println("Unable to save snapshot. Error:", err)
+	}
+	server.writeResp(w, http.StatusCreated, &errorResp{})
 }
 
 func (server *providerServer) getBlock(w http.ResponseWriter, r *http.Request) {
@@ -164,76 +163,74 @@ func (server *providerServer) getBlock(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (server *providerServer) deleteBlockHandler() http.HandlerFunc {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		blockquery, exists := r.URL.Query()["blockID"]
-		if !exists {
-			server.writeResp(w, http.StatusBadRequest, &errorResp{Error: "No block given"})
-			return
-		}
-		blockID := blockquery[0]
+func (server *providerServer) deleteBlock(w http.ResponseWriter, r *http.Request) {
+	blockquery, exists := r.URL.Query()["blockID"]
+	if !exists {
+		server.writeResp(w, http.StatusBadRequest, &errorResp{Error: "No block given"})
+		return
+	}
+	blockID := blockquery[0]
 
-		// TODO: Replace this with authorization token
-		renterquery, exists := r.URL.Query()["renterID"]
-		if !exists {
-			server.writeResp(w, http.StatusBadRequest, errorResp{Error: "No renter ID given"})
-			return
-		}
-		renterID := renterquery[0]
-		renter, exists := server.provider.renters[renterID]
-		if !exists {
-			server.writeResp(w, http.StatusBadRequest,
-				errorResp{Error: "No contracts found for given renter"})
-			return
-		}
+	// TODO: Replace this with authorization token
+	renterquery, exists := r.URL.Query()["renterID"]
+	if !exists {
+		server.writeResp(w, http.StatusBadRequest, errorResp{Error: "No renter ID given"})
+		return
+	}
+	renterID := renterquery[0]
+	renter, exists := server.provider.renters[renterID]
+	if !exists {
+		server.writeResp(w, http.StatusBadRequest,
+			errorResp{Error: "No contracts found for given renter"})
+		return
+	}
 
-		claims, err := util.GetTokenClaimsFromRequest(r)
-		if err != nil {
-			server.writeResp(w, http.StatusInternalServerError,
-				errorResp{Error: "Failure parsing authentication token"})
-			return
-		}
+	claims, err := util.GetTokenClaimsFromRequest(r)
+	if err != nil {
+		server.writeResp(w, http.StatusInternalServerError,
+			errorResp{Error: "Failure parsing authentication token"})
+		return
+	}
 
-		// Check to confirm that the authentication token matches that of the querying renter
-		if claimID, present := claims["renterID"]; !present || claimID.(string) != renterID {
-			server.writeResp(w, http.StatusForbidden, errorResp{Error: "Authentication token does not match renterID"})
-			return
-		}
+	// Check to confirm that the authentication token matches that of the querying renter
+	if claimID, present := claims["renterID"]; !present || claimID.(string) != renterID {
+		server.writeResp(w, http.StatusForbidden, errorResp{Error: "Authentication token does not match renterID"})
+		return
+	}
 
-		path := path.Join(server.provider.Homedir, "blocks", renterID, blockID)
-		fi, err := os.Stat(path)
-		if err != nil && os.IsNotExist(err) {
-			msg := fmt.Sprintf("Cannot find block with ID %s", blockID)
-			server.writeResp(w, http.StatusBadRequest, errorResp{Error: msg})
-			return
-		}
+	path := path.Join(server.provider.Homedir, "blocks", renterID, blockID)
+	fi, err := os.Stat(path)
+	if err != nil && os.IsNotExist(err) {
+		msg := fmt.Sprintf("Cannot find block with ID %s", blockID)
+		server.writeResp(w, http.StatusBadRequest, errorResp{Error: msg})
+		return
+	}
 
-		err = os.Remove(path)
-		if err != nil {
-			msg := fmt.Sprintf("Error deleting block with ID %s", blockID)
-			server.writeResp(w, http.StatusBadRequest, errorResp{Error: msg})
-			return
-		}
+	err = os.Remove(path)
+	if err != nil {
+		msg := fmt.Sprintf("Error deleting block with ID %s", blockID)
+		server.writeResp(w, http.StatusBadRequest, errorResp{Error: msg})
+		return
+	}
 
-		for i, block := range renter.Blocks {
-			if block.BlockId == blockID {
-				renter.Blocks = append(renter.Blocks[:i], renter.Blocks[i+1:]...)
-				server.provider.stats.StorageUsed -= fi.Size()
-				renter.StorageUsed -= fi.Size()
-			}
+	for i, block := range renter.Blocks {
+		if block.BlockId == blockID {
+			renter.Blocks = append(renter.Blocks[:i], renter.Blocks[i+1:]...)
+			server.provider.stats.StorageUsed -= fi.Size()
+			renter.StorageUsed -= fi.Size()
 		}
+	}
 
-		activity := Activity{
-			RequestType: deleteBlockType,
-			BlockId:     blockID,
-			TimeStamp:   time.Now(),
-			RenterId:    renterID,
-		}
-		server.provider.addActivity(activity)
-		err = server.provider.saveSnapshot()
-		if err != nil {
-			server.logger.Println("Error saving snapshot: ", err)
-		}
-		server.writeResp(w, http.StatusOK, &errorResp{})
-	})
+	activity := Activity{
+		RequestType: deleteBlockType,
+		BlockId:     blockID,
+		TimeStamp:   time.Now(),
+		RenterId:    renterID,
+	}
+	server.provider.addActivity(activity)
+	err = server.provider.saveSnapshot()
+	if err != nil {
+		server.logger.Println("Error saving snapshot: ", err)
+	}
+	server.writeResp(w, http.StatusOK, &errorResp{})
 }

--- a/provider/local.go
+++ b/provider/local.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"skybin/core"
 
 	"github.com/gorilla/mux"
 )
@@ -25,8 +26,8 @@ func NewLocalServer(provider *Provider, logger *log.Logger) http.Handler {
 		router:   router,
 	}
 
-	router.HandleFunc("/info", server.postInfo).Methods("POST")
-	router.HandleFunc("/stats", server.getStats).Methods("GET")
+	router.HandleFunc("/config", server.postConfig).Methods("POST")
+	router.HandleFunc("/info", server.getInfo).Methods("GET")
 	router.HandleFunc("/activity", server.getActivity).Methods("GET")
 	router.HandleFunc("/contracts", server.getContracts).Methods("GET")
 
@@ -38,37 +39,25 @@ func (server *localServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	server.router.ServeHTTP(w, r)
 }
 
-// This will be used to access statistics to fill out the provider dashboard
-func (server *localServer) getStats(w http.ResponseWriter, r *http.Request) {
-	reserved := server.provider.stats.StorageReserved
-	used := server.provider.stats.StorageUsed
-	free := reserved - used
-
-	info := getInfoResp{
-		ProviderId:      server.provider.Config.ProviderID,
-		TotalStorage:    server.provider.Config.SpaceAvail,
-		ReservedStorage: reserved,
-		UsedStorage:     used, //maybe delete these fields
-		FreeStorage:     free, //maybe delete these fields
-		TotalContracts:  len(server.provider.contracts),
-	}
-
-	server.writeResp(w, http.StatusOK, &info)
+func (server *localServer) getInfo(w http.ResponseWriter, r *http.Request) {
+	info := server.provider.GetInfo()
+	server.writeResp(w, http.StatusOK, info)
 }
 
-// This could potentially be consolidated into the getStats object
+type getContractsResp struct {
+	Contracts []*core.Contract `json:"contracts"`
+}
+
 func (server *localServer) getContracts(w http.ResponseWriter, r *http.Request) {
 	server.writeResp(w, http.StatusOK,
 		getContractsResp{Contracts: server.provider.contracts})
 }
 
-// This could potentially be consolidated into the getStats object
 func (server *localServer) getActivity(w http.ResponseWriter, r *http.Request) {
 	server.writeResp(w, http.StatusOK, &getActivityResp{Activity: server.provider.activity})
 }
 
-// Info object for when a provider saves in UI
-func (server *localServer) postInfo(w http.ResponseWriter, r *http.Request) {
+func (server *localServer) postConfig(w http.ResponseWriter, r *http.Request) {
 	var params Config
 	err := json.NewDecoder(r.Body).Decode(&params)
 	if err != nil {
@@ -88,20 +77,10 @@ func (server *localServer) postInfo(w http.ResponseWriter, r *http.Request) {
 	server.writeResp(w, http.StatusOK, &errorResp{})
 }
 
-type getInfoResp struct {
-	ProviderId      string `json:"providerId"`
-	TotalStorage    int64  `json:"providerAllocated"`
-	ReservedStorage int64  `json:"providerReserved"`
-	UsedStorage     int64  `json:"providerUsed"`
-	FreeStorage     int64  `json:"providerFree"`
-	TotalContracts  int    `json:"providerContracts"`
-}
-
 type getActivityResp struct {
 	Activity []Activity `json:"activity"`
 }
 
-//TODO: refactor this into a single function between local and public???
 func (server *localServer) writeResp(w http.ResponseWriter, status int, body interface{}) {
 	w.WriteHeader(status)
 	data, err := json.MarshalIndent(body, "", "    ")

--- a/provider/negotiate.go
+++ b/provider/negotiate.go
@@ -1,0 +1,65 @@
+package provider
+
+import (
+	"fmt"
+	"time"
+	"skybin/core"
+	"errors"
+)
+
+func (provider *Provider) NegotiateContract(contract *core.Contract) (*core.Contract, error) {
+	renterKey, err := provider.getRenterPublicKey(contract.RenterId)
+	if err != nil {
+		return nil, errors.New("Metadata server does not have an associated renter ID")
+	}
+
+	// Verify renters signature
+	err = core.VerifyContractSignature(contract, contract.RenterSignature, *renterKey)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid Renter signature: %s", err)
+	}
+
+	// Determine if provider has sufficient space available for the contract
+	avail := provider.Config.SpaceAvail - provider.stats.StorageReserved
+	if contract.StorageSpace > avail {
+		return nil, errors.New("Provider does not have sufficient storage available")
+	}
+
+	// Sign contract
+	provSig, err := core.SignContract(contract, provider.PrivateKey)
+	if err != nil {
+		return nil, errors.New("Error signing contract")
+	}
+	contract.ProviderSignature = provSig
+
+	// Add storage space to the renter
+	renter, exists := provider.renters[contract.RenterId]
+	if !exists {
+		renter = &RenterInfo{
+			Contracts: []*core.Contract{},
+			Blocks:    []*BlockInfo{},
+		}
+		provider.renters[contract.RenterId] = renter
+	}
+	renter.StorageReserved += contract.StorageSpace
+	renter.Contracts = append(renter.Contracts, contract)
+	provider.stats.StorageReserved += contract.StorageSpace
+	provider.contracts = append(provider.contracts, contract)
+
+	activity := Activity{
+		RequestType: negotiateType,
+		Contract:    contract,
+		TimeStamp:   time.Now(),
+		RenterId:    contract.RenterId,
+	}
+	provider.addActivity(activity)
+
+	err = provider.saveSnapshot()
+	if err != nil {
+
+		// TODO: Remove contract. I don't do this here
+		// since we need to move to an improved storage scheme anyways.
+		return nil, fmt.Errorf("Unable to save contract. Error: %s", err)
+	}
+	return contract, nil
+}

--- a/provider/server.go
+++ b/provider/server.go
@@ -48,8 +48,8 @@ func NewServer(provider *Provider, logger *log.Logger) http.Handler {
 	router.HandleFunc("/blocks", server.deleteBlock).Methods("DELETE")
 	router.HandleFunc("/blocks/audit", server.postAudit).Methods("POST")
 
-	router.HandleFunc("/auth", server.authorizer.GetAuthChallengeHandler("renterID")).Methods("GET")
-	router.HandleFunc("/auth", server.authorizer.GetRespondAuthChallengeHandler(
+	router.HandleFunc("/auth/renter", server.authorizer.GetAuthChallengeHandler("renterID")).Methods("GET")
+	router.HandleFunc("/auth/renter", server.authorizer.GetRespondAuthChallengeHandler(
 		"renterID",
 		util.MarshalPrivateKey(server.provider.PrivateKey),
 		server.provider.getRenterPublicKey)).Methods("POST")

--- a/renter/config.go
+++ b/renter/config.go
@@ -1,0 +1,43 @@
+package renter
+
+type Config struct {
+	RenterId            string `json:"renterId"`
+	Alias               string `json:"alias"`
+	ApiAddr             string `json:"apiAddress"`
+	MetaAddr            string `json:"metaServerAddress"`
+	PrivateKeyFile      string `json:"privateKeyFile"`
+	PublicKeyFile       string `json:"publicKeyFile"`
+	MaxContractSize     int64  `json:"maxContractSize"`
+	MaxBlockSize        int64  `json:"maxBlockSize"`
+	DefaultDataBlocks   int    `json:"defaultDataBlocks"`
+	DefaultParityBlocks int    `json:"defaultParityBlocks"`
+}
+
+const (
+
+	// The minimum size of a storage blob
+	kMinBlobSize = 1
+
+	// Minimum contract storage amount
+	// A user cannot reserve less storage than this
+	kMinContractSize = 1024 * 1024
+
+	// Maximum storage amount of any contract
+	kDefaultMaxContractSize = 1024 * 1024 * 1024
+
+	// Maximum size of any file block
+	kDefaultMaxBlockSize = kDefaultMaxContractSize
+
+	// Erasure encoding defaults
+	kDefaultDataBlocks   = 8
+	kDefaultParityBlocks = 4
+)
+
+func DefaultConfig() *Config {
+	return &Config{
+		MaxContractSize:     kDefaultMaxContractSize,
+		MaxBlockSize:        kDefaultMaxBlockSize,
+		DefaultDataBlocks:   kDefaultDataBlocks,
+		DefaultParityBlocks: kDefaultParityBlocks,
+	}
+}

--- a/renter/config.go
+++ b/renter/config.go
@@ -1,16 +1,17 @@
 package renter
 
 type Config struct {
-	RenterId            string `json:"renterId"`
-	Alias               string `json:"alias"`
-	ApiAddr             string `json:"apiAddress"`
-	MetaAddr            string `json:"metaServerAddress"`
-	PrivateKeyFile      string `json:"privateKeyFile"`
-	PublicKeyFile       string `json:"publicKeyFile"`
-	MaxContractSize     int64  `json:"maxContractSize"`
-	MaxBlockSize        int64  `json:"maxBlockSize"`
-	DefaultDataBlocks   int    `json:"defaultDataBlocks"`
-	DefaultParityBlocks int    `json:"defaultParityBlocks"`
+	RenterId                    string `json:"renterId"`
+	Alias                       string `json:"alias"`
+	ApiAddr                     string `json:"apiAddress"`
+	MetaAddr                    string `json:"metaServerAddress"`
+	PrivateKeyFile              string `json:"privateKeyFile"`
+	PublicKeyFile               string `json:"publicKeyFile"`
+	MaxContractSize             int64  `json:"maxContractSize"`
+	MaxBlockSize                int64  `json:"maxBlockSize"`
+	DefaultDataBlocks           int    `json:"defaultDataBlocks"`
+	DefaultParityBlocks         int    `json:"defaultParityBlocks"`
+	DefaultContractDurationDays int    `json:"defaultContractDurationDays"`
 }
 
 const (
@@ -31,13 +32,17 @@ const (
 	// Erasure encoding defaults
 	kDefaultDataBlocks   = 8
 	kDefaultParityBlocks = 4
+
+	// Default contract duration - 6 months
+	kDefaultContractDurationDays = 30 * 6
 )
 
 func DefaultConfig() *Config {
 	return &Config{
-		MaxContractSize:     kDefaultMaxContractSize,
-		MaxBlockSize:        kDefaultMaxBlockSize,
-		DefaultDataBlocks:   kDefaultDataBlocks,
-		DefaultParityBlocks: kDefaultParityBlocks,
+		MaxContractSize:             kDefaultMaxContractSize,
+		MaxBlockSize:                kDefaultMaxBlockSize,
+		DefaultDataBlocks:           kDefaultDataBlocks,
+		DefaultParityBlocks:         kDefaultParityBlocks,
+		DefaultContractDurationDays: kDefaultContractDurationDays,
 	}
 }

--- a/renter/renter.go
+++ b/renter/renter.go
@@ -99,11 +99,12 @@ const (
 
 func LoadFromDisk(homedir string) (*Renter, error) {
 	renter := &Renter{
-		Homedir:   homedir,
-		files:     make([]*core.File, 0),
-		contracts: make([]*core.Contract, 0),
-		freelist:  make([]*storageBlob, 0),
-		logger:    log.New(ioutil.Discard, "", log.LstdFlags),
+		Homedir:        homedir,
+		files:          make([]*core.File, 0),
+		contracts:      make([]*core.Contract, 0),
+		freelist:       make([]*storageBlob, 0),
+		blocksToDelete: make([]*core.Block, 0),
+		logger:         log.New(ioutil.Discard, "", log.LstdFlags),
 	}
 
 	config := &Config{}

--- a/renter/renter.go
+++ b/renter/renter.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 
 	"github.com/satori/go.uuid"
+	"log"
+	"time"
 )
 
 type Config struct {
@@ -27,30 +29,44 @@ type Config struct {
 	MetaAddr       string `json:"metaServerAddress"`
 	PrivateKeyFile string `json:"privateKeyFile"`
 	PublicKeyFile  string `json:"publicKeyFile"`
-
-	// Is this renter node registered with the metaservice?
-	IsRegistered bool `json:"isRegistered"`
 }
 
 type Renter struct {
-	Config     *Config
-	Homedir    string
-	files      []*core.File
-	contracts  []*core.Contract
-	privKey    *rsa.PrivateKey
-	metaClient *metaserver.Client
+	Config  *Config
+	Homedir string
+	privKey *rsa.PrivateKey
 
-	// All free storage blobs available for uploads.
+	// An in-memory cache of the renter's file and contract metadata.
+	files     []*core.File
+	contracts []*core.Contract
+
+	// All free storage blobs available for file uploads.
 	// Each storage contract should have at most one associated
 	// blob in this list.
 	freelist []*storageBlob
+
+	// Metaserver client. The metaserver should always have an up-to-date
+	// view of every file and contract we store locally. However, the
+	// opposite is not necessarily true; we may not have an up-to-date
+	// view of everything the metaserver stores on our behalf.
+	metaClient *metaserver.Client
+
+	// The last time we pulled down a list of our files from the metaserver.
+	lastFilesUpdate time.Time
+
+	// Blocks which need to be removed but could not be immediately
+	// deleted because the provider storing them was offline.
+	blocksToDelete []*core.Block
+
+	logger *log.Logger
 }
 
 // snapshot stores a renter's serialized state
 type snapshot struct {
-	Files       []*core.File     `json:"files"`
-	Contracts   []*core.Contract `json:"contracts"`
-	FreeStorage []*storageBlob   `json:"freeStorage"`
+	Files          []*core.File     `json:"files"`
+	Contracts      []*core.Contract `json:"contracts"`
+	FreeStorage    []*storageBlob   `json:"freeStorage"`
+	BlocksToDelete []*core.Block    `json:"blocksToDelete"`
 }
 
 // storageBlob is a chunk of free storage we've already rented
@@ -87,6 +103,7 @@ func LoadFromDisk(homedir string) (*Renter, error) {
 		files:     make([]*core.File, 0),
 		contracts: make([]*core.Contract, 0),
 		freelist:  make([]*storageBlob, 0),
+		logger:    log.New(ioutil.Discard, "", log.LstdFlags),
 	}
 
 	config := &Config{}
@@ -96,8 +113,7 @@ func LoadFromDisk(homedir string) (*Renter, error) {
 	}
 	renter.Config = config
 
-	metaHTTPClient := http.Client{}
-	renter.metaClient = metaserver.NewClient(config.MetaAddr, &metaHTTPClient)
+	renter.metaClient = metaserver.NewClient(config.MetaAddr, &http.Client{})
 
 	snapshotPath := path.Join(homedir, "snapshot.json")
 	if _, err := os.Stat(snapshotPath); err == nil {
@@ -109,6 +125,7 @@ func LoadFromDisk(homedir string) (*Renter, error) {
 		renter.files = s.Files
 		renter.contracts = s.Contracts
 		renter.freelist = s.FreeStorage
+		renter.blocksToDelete = s.BlocksToDelete
 	}
 
 	privKey, err := loadPrivateKey(path.Join(homedir, "renterid"))
@@ -120,18 +137,18 @@ func LoadFromDisk(homedir string) (*Renter, error) {
 	return renter, err
 }
 
-func (r *Renter) authorize() error {
-	privKey, err := loadPrivateKey(r.Config.PrivateKeyFile)
-	if err != nil {
-		return err
-	}
+func (r *Renter) SetLogger(logger *log.Logger) {
+	r.logger = logger
+}
 
-	err = r.metaClient.AuthorizeRenter(privKey, r.Config.RenterId)
-	if err != nil {
-		return err
+func (r *Renter) saveSnapshot() error {
+	s := snapshot{
+		Files:          r.files,
+		Contracts:      r.contracts,
+		FreeStorage:    r.freelist,
+		BlocksToDelete: r.blocksToDelete,
 	}
-
-	return nil
+	return util.SaveJson(path.Join(r.Homedir, "snapshot.json"), &s)
 }
 
 // Info is information about a renter
@@ -190,23 +207,50 @@ func (r *Renter) CreateFolder(name string) (*core.File, error) {
 }
 
 func (r *Renter) RenameFile(fileId string, name string) (*core.File, error) {
-	file, err := r.Lookup(fileId)
+	file, err := r.GetFile(fileId)
 	if err != nil {
 		return nil, err
 	}
-	for _, file2 := range r.files {
+	files, err := r.ListFiles()
+	if err != nil {
+		return nil, err
+	}
+	for _, file2 := range files {
 		if file2.Name == name {
 			return nil, errors.New("Cannot rename file. Name already taken")
 		}
 	}
+
+	err = r.authorizeMeta()
+	if err != nil {
+		return nil, err
+	}
+
+	// If it's a folder, rename it's children.
 	if file.IsDir {
 		children := r.findChildren(file)
 		for _, child := range children {
 			suffix := strings.TrimPrefix(child.Name, file.Name)
 			child.Name = name + suffix
 		}
+
+		// TODO(kincaid): We need to make these renames atomic.
+		// Perhaps move the rename logic to the metaserver to ensure consistency.
+		for _, child := range children {
+			err := r.metaClient.UpdateFile(r.Config.RenterId, child)
+			if err != nil {
+				return nil, err
+				r.logger.Println("RenameFile: Error updating child's name with metaserver:", err)
+			}
+		}
 	}
+
 	file.Name = name
+	err = r.metaClient.UpdateFile(r.Config.RenterId, file)
+	if err != nil {
+		return nil, err
+	}
+
 	err = r.saveSnapshot()
 	if err != nil {
 		return nil, err
@@ -215,12 +259,42 @@ func (r *Renter) RenameFile(fileId string, name string) (*core.File, error) {
 }
 
 func (r *Renter) ListFiles() ([]*core.File, error) {
+	if time.Now().After(r.lastFilesUpdate.Add(5 * time.Minute)) {
+		err := r.pullFiles()
+		if err != nil {
+			r.logger.Println("Unable to refresh file metadata cache. Error: ", err)
+		}
+	}
 	return r.files, nil
 }
 
+// Refreshes the local list of files from the metaserver
+func (r *Renter) pullFiles() error {
+	err := r.authorizeMeta()
+	if err != nil {
+		return err
+	}
+
+	files, err := r.metaClient.GetFiles(r.Config.RenterId)
+	if err != nil {
+		return err
+	}
+
+	// Ugly conversion of []File to []*File
+	r.files = []*core.File{}
+	for _, file := range files {
+		r.files = append(r.files, &file)
+	}
+
+	r.lastFilesUpdate = time.Now()
+
+	return r.saveSnapshot()
+}
+
 func (r *Renter) ListSharedFiles() ([]*core.File, error) {
-	if !r.metaClient.IsAuthorized() {
-		r.authorize()
+	err := r.authorizeMeta()
+	if err != nil {
+		return nil, err
 	}
 
 	files, err := r.metaClient.GetSharedFiles(r.Config.RenterId)
@@ -237,27 +311,33 @@ func (r *Renter) ListSharedFiles() ([]*core.File, error) {
 	return returnList, nil
 }
 
-func (r *Renter) Lookup(fileId string) (*core.File, error) {
-	_, f := r.findFile(fileId)
-	if f != nil {
-		return f, nil
+func (r *Renter) GetFile(fileId string) (*core.File, error) {
+
+	// Check if it exists locally
+	for _, file := range r.files {
+		if file.ID == fileId {
+			return file, nil
+		}
 	}
 
-	// If we couldn't find the file locally, check if it is a shared file.
-	if !r.metaClient.IsAuthorized() {
-		r.authorize()
+	// It might not exist because the local cache is out of date.
+	// Check with the metaserver.
+	err := r.authorizeMeta()
+	if err != nil {
+		return nil, err
 	}
-
-	f, err := r.metaClient.GetFile(r.Config.RenterId, fileId)
+	file, err := r.metaClient.GetFile(r.Config.RenterId, fileId)
 	if err != nil {
 		return nil, err
 	}
 
-	return f, nil
+	r.files = append(r.files, file)
+
+	return file, nil
 }
 
 func (r *Renter) ShareFile(fileId string, renterAlias string) error {
-	f, err := r.Lookup(fileId)
+	file, err := r.GetFile(fileId)
 	if err != nil {
 		return err
 	}
@@ -274,7 +354,7 @@ func (r *Renter) ShareFile(fileId string, renterAlias string) error {
 		return err
 	}
 
-	decryptedKey, decryptedIV, err := r.decryptEncryptionKeys(f)
+	decryptedKey, decryptedIV, err := r.decryptEncryptionKeys(file)
 	if err != nil {
 		return err
 	}
@@ -289,19 +369,17 @@ func (r *Renter) ShareFile(fileId string, renterAlias string) error {
 		AesIV:    base64.URLEncoding.EncodeToString(encryptedIV),
 	}
 
-	if !r.metaClient.IsAuthorized() {
-		err = r.authorize()
-		if err != nil {
-			return err
-		}
-	}
-
-	err = r.metaClient.ShareFile(r.Config.RenterId, f.ID, &permission)
+	err = r.authorizeMeta()
 	if err != nil {
 		return err
 	}
 
-	f.AccessList = append(f.AccessList, permission)
+	err = r.metaClient.ShareFile(r.Config.RenterId, file.ID, &permission)
+	if err != nil {
+		return err
+	}
+
+	file.AccessList = append(file.AccessList, permission)
 	err = r.saveSnapshot()
 	if err != nil {
 		return fmt.Errorf("Unable to save snapshot. Error %s", err)
@@ -309,53 +387,70 @@ func (r *Renter) ShareFile(fileId string, renterAlias string) error {
 	return nil
 }
 
-func (r *Renter) Remove(fileId string) error {
-	idx, f := r.findFile(fileId)
-	if f == nil {
-		return fmt.Errorf("Cannot find file with ID %s", fileId)
+func (r *Renter) RemoveFile(fileId string) error {
+	file, err := r.GetFile(fileId)
+	if err != nil {
+		return err
 	}
-	if f.IsDir && len(r.findChildren(f)) > 0 {
+	if file.IsDir && len(r.findChildren(file)) > 0 {
 		return errors.New("Cannot remove non-empty folder")
 	}
-	for _, version := range f.Versions {
+	for _, version := range file.Versions {
 		r.removeVersion(&version)
 	}
-	r.files = append(r.files[:idx], r.files[idx+1:]...)
-	err := r.saveSnapshot()
+	err = r.metaClient.DeleteFile(r.Config.RenterId, fileId)
 	if err != nil {
-		return fmt.Errorf("Unable to save snapshot. Error: %s", err)
+		return err
 	}
+
+	// Delete locally
+	fileIdx := -1
+	for idx, file := range r.files {
+		if file.ID == fileId {
+			fileIdx = idx
+			break
+		}
+	}
+	if fileIdx != -1 {
+		r.files = append(r.files[:fileIdx], r.files[fileIdx+1:]...)
+		err = r.saveSnapshot()
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 func (r *Renter) removeVersion(version *core.Version) {
 	for _, block := range version.Blocks {
-		err := r.removeBlock(&block)
-		if err != nil {
-			// TODO: add to list to remove later
-			continue
-		}
-		for _, location := range block.Locations {
-			blob := &storageBlob{
-				ProviderId: location.ProviderId,
-				Addr:       location.Addr,
-				Amount:     block.Size,
-				ContractId: location.ContractId,
-			}
-			r.addBlob(blob)
-		}
+		r.removeBlock(&block)
 	}
 }
 
-func (r *Renter) removeBlock(block *core.Block) error {
-	for _, location := range block.Locations {
-		pvdr := provider.NewClient(location.Addr, &http.Client{})
-		err := pvdr.RemoveBlock(r.Config.RenterId, block.ID)
-		if err != nil {
-			return err
-		}
+// Removes a block from the provider where it is stored, reclaiming
+// the block's storage for the freelist.
+func (r *Renter) removeBlock(block *core.Block) {
+	pvdr := provider.NewClient(block.Location.Addr, &http.Client{})
+	err := pvdr.AuthorizeRenter(r.privKey, r.Config.RenterId)
+	if err == nil {
+		err = pvdr.RemoveBlock(r.Config.RenterId, block.ID)
 	}
-	return nil
+	if err != nil {
+		r.logger.Println("Unable to remove block %s from provider %s\n",
+			block.ID, block.Location.ProviderId)
+		r.logger.Printf("Error: %s\n", err)
+		r.blocksToDelete = append(r.blocksToDelete, block)
+	}
+
+	// Reclaim the storage used by the block.
+	blob := &storageBlob{
+		ProviderId: block.Location.ProviderId,
+		Addr:       block.Location.Addr,
+		Amount:     block.Size,
+		ContractId: block.Location.ContractId,
+	}
+	r.addBlob(blob)
 }
 
 // Add a storage blob back to the free list.
@@ -363,7 +458,7 @@ func (r *Renter) addBlob(blob *storageBlob) {
 	for _, blob2 := range r.freelist {
 		if blob.ContractId == blob2.ContractId {
 
-			// Merge
+			// Merge blobs
 			blob2.Amount += blob.Amount
 			return
 		}
@@ -372,17 +467,16 @@ func (r *Renter) addBlob(blob *storageBlob) {
 }
 
 func (r *Renter) saveFile(f *core.File) error {
+	err := r.authorizeMeta()
+	if err != nil {
+		return err
+	}
+	err = r.metaClient.PostFile(r.Config.RenterId, f)
+	if err != nil {
+		return err
+	}
 	r.files = append(r.files, f)
 	return r.saveSnapshot()
-}
-
-func (r *Renter) findFile(fileId string) (idx int, f *core.File) {
-	for idx, f = range r.files {
-		if f.ID == fileId {
-			return
-		}
-	}
-	return -1, nil
 }
 
 func (r *Renter) findChildren(dir *core.File) []*core.File {
@@ -398,13 +492,15 @@ func (r *Renter) findChildren(dir *core.File) []*core.File {
 	return children
 }
 
-func (r *Renter) saveSnapshot() error {
-	s := snapshot{
-		Files:       r.files,
-		Contracts:   r.contracts,
-		FreeStorage: r.freelist,
+// Authorize with the metaclient, if necessary
+func (r *Renter) authorizeMeta() error {
+	if !r.metaClient.IsAuthorized() {
+		err := r.metaClient.AuthorizeRenter(r.privKey, r.Config.RenterId)
+		if err != nil {
+			return fmt.Errorf("Unable to authorize with metaserver. Error: %s", err)
+		}
 	}
-	return util.SaveJson(path.Join(r.Homedir, "snapshot.json"), &s)
+	return nil
 }
 
 func loadPrivateKey(path string) (*rsa.PrivateKey, error) {

--- a/renter/renter.go
+++ b/renter/renter.go
@@ -22,15 +22,6 @@ import (
 	"time"
 )
 
-type Config struct {
-	RenterId       string `json:"renterId"`
-	Alias          string `json:"alias"`
-	ApiAddr        string `json:"apiAddress"`
-	MetaAddr       string `json:"metaServerAddress"`
-	PrivateKeyFile string `json:"privateKeyFile"`
-	PublicKeyFile  string `json:"publicKeyFile"`
-}
-
 type Renter struct {
 	Config  *Config
 	Homedir string
@@ -76,26 +67,6 @@ type storageBlob struct {
 	Amount     int64  // The free storage in bytes
 	ContractId string // The contract the blob is associated with
 }
-
-const (
-
-	// The minimum size of a storage blob
-	kMinBlobSize = 1
-
-	// Minimum contract storage amount
-	// A user cannot reserve less storage than this
-	kMinContractSize = 1024 * 1024
-
-	// Maximum storage amount of any contract
-	kMaxContractSize = 1024 * 1024 * 1024
-
-	// Maximum size of an uploaded block
-	kMaxBlockSize = kMaxContractSize
-
-	// Erasure encoding defaults
-	kDefaultDataBlocks   = 8
-	kDefaultParityBlocks = 4
-)
 
 func LoadFromDisk(homedir string) (*Renter, error) {
 	renter := &Renter{

--- a/renter/renter.go
+++ b/renter/renter.go
@@ -314,6 +314,10 @@ func (r *Renter) ShareFile(fileId string, renterAlias string) error {
 		return err
 	}
 
+	if file.IsDir {
+		return errors.New("Folder sharing not supported")
+	}
+
 	// Get the renter's information
 	renterInfo, err := r.metaClient.GetRenterByAlias(renterAlias)
 	if err != nil {

--- a/renter/reserve.go
+++ b/renter/reserve.go
@@ -8,6 +8,7 @@ import (
 	"skybin/core"
 	"skybin/provider"
 	"skybin/util"
+	"time"
 )
 
 func (r *Renter) ReserveStorage(amount int64) ([]*core.Contract, error) {
@@ -116,6 +117,8 @@ func (r *Renter) formContract(space int64, pinfo *core.ProviderInfo) (*core.Cont
 	}
 	proposal := core.Contract{
 		ID:           cid,
+		StartDate:    time.Now().UTC().Round(0),
+		EndDate:      time.Now().AddDate(0, 0, r.Config.DefaultContractDurationDays),
 		RenterId:     r.Config.RenterId,
 		ProviderId:   pinfo.ID,
 		StorageSpace: space,

--- a/renter/reserve.go
+++ b/renter/reserve.go
@@ -25,8 +25,8 @@ func (r *Renter) ReserveStorage(amount int64) ([]*core.Contract, error) {
 	var blobs []*storageBlob
 	for reserved < amount {
 		n := amount - reserved
-		if n > kMaxContractSize {
-			n = kMaxContractSize
+		if n > r.Config.MaxContractSize {
+			n = r.Config.MaxContractSize
 		}
 		contract, pinfo, err := r.reserveN(n, providers)
 		if err != nil {

--- a/renter/server.go
+++ b/renter/server.go
@@ -152,8 +152,9 @@ func (server *renterServer) uploadFile(w http.ResponseWriter, r *http.Request) {
 }
 
 type downloadFileReq struct {
-	FileId   string `json:"fileId"`
-	DestPath string `json:"destPath"`
+	FileId     string `json:"fileId"`
+	DestPath   string `json:"destPath"`
+	VersionNum *int   `json:"versionNum"`
 }
 
 func (server *renterServer) downloadFile(w http.ResponseWriter, r *http.Request) {
@@ -166,7 +167,7 @@ func (server *renterServer) downloadFile(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	err = server.renter.Download(req.FileId, req.DestPath)
+	err = server.renter.Download(req.FileId, req.DestPath, req.VersionNum)
 	if err != nil {
 		server.logger.Println(err)
 		server.writeResp(w, http.StatusInternalServerError,
@@ -269,7 +270,8 @@ func (server *renterServer) copyFile(w http.ResponseWriter, r *http.Request) {
 }
 
 type removeFileReq struct {
-	FileID string `json:"fileID"`
+	FileID     string `json:"fileID"`
+	VersionNum *int   `json:"versionNum"`
 }
 
 func (server *renterServer) removeFile(w http.ResponseWriter, r *http.Request) {
@@ -282,7 +284,7 @@ func (server *renterServer) removeFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = server.renter.RemoveFile(req.FileId)
+	err = server.renter.RemoveFile(req.FileId, req.VersionNum)
 	if err != nil {
 		server.logger.Println(err)
 		server.writeResp(w, http.StatusInternalServerError,

--- a/renter/server.go
+++ b/renter/server.go
@@ -282,7 +282,7 @@ func (server *renterServer) removeFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = server.renter.Remove(req.FileId)
+	err = server.renter.RemoveFile(req.FileId)
 	if err != nil {
 		server.logger.Println(err)
 		server.writeResp(w, http.StatusInternalServerError,

--- a/renter/upload.go
+++ b/renter/upload.go
@@ -10,28 +10,184 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/klauspost/reedsolomon"
 	"io"
 	"io/ioutil"
 	mathrand "math/rand"
 	"net/http"
 	"os"
+	"path/filepath"
 	"skybin/core"
 	"skybin/provider"
-
-	"github.com/klauspost/reedsolomon"
+	"skybin/util"
+	"strings"
 )
 
 func (r *Renter) Upload(srcPath string, destPath string, shouldOverwrite bool) (*core.File, error) {
+	destPath = util.CleanPath(destPath)
 	finfo, err := os.Stat(srcPath)
 	if err != nil {
 		return nil, err
 	}
+	existingFile := r.getFileByName(destPath)
+	if existingFile != nil && finfo.IsDir() {
+		return nil, errors.New("A file with that name already exists.")
+	}
 	if finfo.IsDir() {
-		return nil, errors.New("Folder uploads not supported yet")
+		return r.uploadDir(srcPath, destPath)
 	}
 	if r.storageAvailable() <= finfo.Size() {
 		return nil, errors.New("Not enough storage")
 	}
+	if existingFile != nil {
+		aesKey, aesIV, err := r.decryptEncryptionKeys(existingFile)
+		if err != nil {
+			return nil, err
+		}
+
+		// Authorize with metaserver before performing upload of new version
+		// to catch authorization error early.
+		err = r.authorizeMeta()
+		if err != nil {
+			return nil, err
+		}
+		newVersion, err := r.performUpload(srcPath, finfo, aesKey, aesIV)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO(Kincaid): These interactions with the metaserver are error prone.
+		// Consider a single convenience endpoint to overwrite the latest version
+		// of a file which returns an updated copy of the file object.
+		err = r.metaClient.PostFileVersion(r.Config.RenterId, existingFile.ID, newVersion)
+		if err != nil {
+			r.removeVersionBlocks(newVersion)
+			return nil, fmt.Errorf("Unable to update version metadata. Error: %s", err)
+		}
+
+		if shouldOverwrite {
+			prevVersion := &existingFile.Versions[len(existingFile.Versions)-1]
+			err = r.metaClient.DeleteFileVersion(r.Config.RenterId, existingFile.ID, prevVersion.Num)
+			if err != nil {
+				r.logger.Println("Unable to overwrite previous file version. Error:", err)
+			} else {
+				r.removeVersionBlocks(prevVersion)
+				existingFile.Versions = existingFile.Versions[:len(existingFile.Versions)-1]
+			}
+		}
+
+		// Pull down the file again to refresh the version information.
+		updatedFile, err := r.metaClient.GetFile(r.Config.RenterId, existingFile.ID)
+		if err != nil {
+			r.logger.Println("Unable to pull updated version of file. Error: %s", err)
+			existingFile.Versions = append(existingFile.Versions, *newVersion)
+			return existingFile, nil
+		}
+		*existingFile = *updatedFile
+		err = r.saveSnapshot()
+		if err != nil {
+			r.logger.Println("Error saving snapshot:", err)
+		}
+		return updatedFile, nil
+	}
+	return r.uploadFile(srcPath, finfo, destPath)
+}
+
+// Uploads a new file from srcPath to destPath. File size and destPath validation
+// should already have been performed. finfo should be the file info for the source file.
+func (r *Renter) uploadFile(srcPath string, finfo os.FileInfo, destPath string) (*core.File, error) {
+	fileId, err := genId()
+	if err != nil {
+		return nil, err
+	}
+	aesKey := make([]byte, 32)
+	_, err = rand.Reader.Read(aesKey)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create encryption key. Error: %s", err)
+	}
+	aesIV := make([]byte, aes.BlockSize)
+	_, err = rand.Reader.Read(aesIV)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to read initialization vector. Error: %s", err)
+	}
+	aesKeyEncrypted, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, &r.privKey.PublicKey, aesKey, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to encrypt aes key. Error: %s", err)
+	}
+	aesIVEncrypted, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, &r.privKey.PublicKey, aesIV, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to encrypt aes IV. Error: %s", err)
+	}
+	version, err := r.performUpload(srcPath, finfo, aesKey, aesIV)
+	if err != nil {
+		return nil, err
+	}
+	file := &core.File{
+		ID:         fileId,
+		OwnerID:    r.Config.RenterId,
+		Name:       destPath,
+		IsDir:      false,
+		AccessList: []core.Permission{},
+		AesKey:     base64.URLEncoding.EncodeToString(aesKeyEncrypted),
+		AesIV:      base64.URLEncoding.EncodeToString(aesIVEncrypted),
+		Versions:   []core.Version{},
+	}
+	// TODO: Kincaid. Do I have to set this?
+	version.Num = 1
+	file.Versions = append(file.Versions, *version)
+	err = r.saveFile(file)
+	if err != nil {
+		r.removeVersionBlocks(version)
+		err2 := r.saveSnapshot()
+		if err2 != nil {
+			r.logger.Println("Error saving snapshot:", err2)
+		}
+	}
+	return file, err
+}
+
+// Uploads a directory from srcPath to destPath. Returns the root folder of the new directory.
+func (r *Renter) uploadDir(srcPath string, destPath string) (*core.File, error) {
+	var size int64
+	err := filepath.Walk(srcPath, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	if r.storageAvailable() <= size {
+		return nil, errors.New("Not enough storage")
+	}
+	var rootFolder *core.File
+	err = filepath.Walk(srcPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		fullPath := destPath
+		if path != srcPath {
+			relPath := strings.TrimPrefix(path, srcPath)
+			fullPath += relPath
+		}
+		if info.IsDir() {
+			f, err := r.CreateFolder(fullPath)
+			if err != nil {
+				return err
+			}
+			if path == srcPath {
+				rootFolder = f
+			}
+			return nil
+		}
+		_, err = r.uploadFile(path, info, fullPath)
+		return err
+	})
+	return rootFolder, nil
+}
+
+func (r *Renter) performUpload(srcPath string, finfo os.FileInfo, aesKey []byte, aesIV []byte) (*core.Version, error) {
 
 	// Compress
 	srcFile, err := os.Open(srcPath)
@@ -53,16 +209,6 @@ func (r *Renter) Upload(srcPath string, destPath string, shouldOverwrite bool) (
 	cw.Close()
 
 	// Encrypt
-	aesKey := make([]byte, 32)
-	_, err = rand.Reader.Read(aesKey)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to create encryption key. Error: %s", err)
-	}
-	aesIV := make([]byte, aes.BlockSize)
-	_, err = rand.Reader.Read(aesIV)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to read initialization vector. Error: %s", err)
-	}
 	aesCipher, err := aes.NewCipher(aesKey)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to create encryption cipher. Error: %s", err)
@@ -166,19 +312,7 @@ func (r *Renter) Upload(srcPath string, destPath string, shouldOverwrite bool) (
 		blocks = append(blocks, block)
 	}
 
-	// Prepare file metadata. This is done before uploading blocks to ease error handling.
-	fileId, err := genId()
-	if err != nil {
-		return nil, err
-	}
-	aesKeyEncrypted, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, &r.privKey.PublicKey, aesKey, nil)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to encrypt aes key. Error: %s", err)
-	}
-	aesIVEncrypted, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, &r.privKey.PublicKey, aesIV, nil)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to encrypt aes IV. Error: %s", err)
-	}
+	// Prepare metadata before actually uploading blocks.
 	uploadSize := blockSize * int64(nDataBlocks)
 	for _, f := range parityFiles {
 		st, err := f.Stat()
@@ -187,26 +321,14 @@ func (r *Renter) Upload(srcPath string, destPath string, shouldOverwrite bool) (
 		}
 		uploadSize += st.Size()
 	}
-	file := &core.File{
-		ID:         fileId,
-		OwnerID:    r.Config.RenterId,
-		Name:       destPath,
-		IsDir:      false,
-		AccessList: make([]core.Permission, 0),
-		AesKey:     base64.URLEncoding.EncodeToString(aesKeyEncrypted),
-		AesIV:      base64.URLEncoding.EncodeToString(aesIVEncrypted),
-		Versions: []core.Version{
-			{
-				Num:             1,
-				Size:            finfo.Size(),
-				UploadSize:      uploadSize,
-				PaddingBytes:    paddingBytes,
-				ModTime:         finfo.ModTime(),
-				NumDataBlocks:   nDataBlocks,
-				NumParityBlocks: nParityBlocks,
-				Blocks:          blocks,
-			},
-		},
+	version := &core.Version{
+		Size:            finfo.Size(),
+		UploadSize:      uploadSize,
+		PaddingBytes:    paddingBytes,
+		ModTime:         finfo.ModTime(),
+		NumDataBlocks:   nDataBlocks,
+		NumParityBlocks: nParityBlocks,
+		Blocks:          blocks,
 	}
 
 	// Seek back to beginning of parity files
@@ -256,11 +378,7 @@ func (r *Renter) Upload(srcPath string, destPath string, shouldOverwrite bool) (
 		}
 	}
 
-	err = r.saveFile(file)
-	if err != nil {
-		goto unwind
-	}
-	return file, nil
+	return version, nil
 
 unwind:
 	for i := 0; i < blockNum; i++ {
@@ -325,12 +443,4 @@ func (r *Renter) findStorage(nblocks int, blockSize int64) ([]*storageBlob, erro
 	}
 
 	return blobs, nil
-}
-
-func (r *Renter) storageAvailable() int64 {
-	var total int64 = 0
-	for _, blob := range r.freelist {
-		total += blob.Amount
-	}
-	return total
 }

--- a/renter/upload.go
+++ b/renter/upload.go
@@ -83,7 +83,7 @@ func (r *Renter) Upload(srcPath string, destPath string, shouldOverwrite bool) (
 			existingFile.Versions = append(existingFile.Versions, *newVersion)
 			return existingFile, nil
 		}
-		*existingFile = *updatedFile
+ 		*existingFile = *updatedFile
 		err = r.saveSnapshot()
 		if err != nil {
 			r.logger.Println("Error saving snapshot:", err)
@@ -132,8 +132,7 @@ func (r *Renter) uploadFile(srcPath string, finfo os.FileInfo, destPath string) 
 		AesIV:      base64.URLEncoding.EncodeToString(aesIVEncrypted),
 		Versions:   []core.Version{},
 	}
-	// TODO: Kincaid. Do I have to set this?
-	version.Num = 1
+	version.Num = 0
 	file.Versions = append(file.Versions, *version)
 	err = r.saveFile(file)
 	if err != nil {

--- a/renter/upload.go
+++ b/renter/upload.go
@@ -236,9 +236,12 @@ func (r *Renter) performUpload(srcPath string, finfo os.FileInfo, aesKey []byte,
 	if err != nil {
 		return nil, fmt.Errorf("Unable to stat temp file. Error: %s", err)
 	}
-	blockSize := (tempStat.Size() + kDefaultDataBlocks - 1) / kDefaultDataBlocks
-	if blockSize > kMaxBlockSize {
-		blockSize = kMaxBlockSize
+	blockSize := (tempStat.Size() + int64(r.Config.DefaultDataBlocks) - 1) / int64(r.Config.DefaultDataBlocks)
+	if blockSize > r.Config.MaxBlockSize {
+		blockSize = r.Config.MaxBlockSize
+	}
+	if blockSize > r.Config.MaxContractSize {
+		blockSize = r.Config.MaxContractSize
 	}
 	// Pad file up to next nearest block size multiple if necessary.
 	// Its size must be a block size multiple.
@@ -250,8 +253,8 @@ func (r *Renter) performUpload(srcPath string, finfo os.FileInfo, aesKey []byte,
 		}
 	}
 	nDataBlocks := int((tempStat.Size() + blockSize - 1) / blockSize)
-	nParityBlocks := kDefaultParityBlocks
-	if nDataBlocks > kDefaultDataBlocks {
+	nParityBlocks := r.Config.DefaultParityBlocks
+	if nDataBlocks > r.Config.DefaultDataBlocks {
 		nParityBlocks = (nDataBlocks + 1) / 2
 	}
 	encoder, err := reedsolomon.NewStream(nDataBlocks, nParityBlocks)

--- a/util/util.go
+++ b/util/util.go
@@ -172,3 +172,11 @@ func GetTokenClaimsFromRequest(r *http.Request) (jwt.MapClaims, error) {
 
 	return claims, nil
 }
+
+// Removes a single leading and trailing slash from a file name.
+func CleanPath(path string) string {
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, "/")
+	return path
+}
+

--- a/util/util.go
+++ b/util/util.go
@@ -2,9 +2,9 @@ package util
 
 import (
 	"crypto/rsa"
-	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
-	"encoding/base32"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -16,15 +16,7 @@ import (
 	"strings"
 
 	"github.com/dgrijalva/jwt-go"
-	"crypto/sha256"
-	"encoding/hex"
 )
-
-func Hash(data []byte) string {
-	h := sha1.New()
-	h.Write(data)
-	return base32.StdEncoding.EncodeToString(h.Sum(nil))
-}
 
 func SaveJson(filename string, v interface{}) error {
 	bytes, err := json.MarshalIndent(v, "", "    ")
@@ -179,4 +171,3 @@ func CleanPath(path string) string {
 	path = strings.TrimSuffix(path, "/")
 	return path
 }
-

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -182,3 +182,12 @@ func TestValidateNetAddr(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestCleanPath(t *testing.T) {
+	if CleanPath("/dir/f1") != "dir/f1" {
+		t.Fatal("Incorrect output path")
+	}
+	if CleanPath("dir/f1/") != "dir/f1" {
+		t.Fatal("Incorrect output path")
+	}
+}


### PR DESCRIPTION
- Fix provider auth endpoints.
- Save renter contract/file metadata with metaserver (but cache locally
as well)
- If a block cannot be deleted, add it to a list of blocks to delete
later.