### PR TITLE
Audits

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -11,14 +11,19 @@ const (
 	DefaultLocalProviderAddr  = "127.0.0.1:8004"
 )
 
+const (
+	// Default length of the nonce of a BlockAudit
+	DefaultAuditNonceLen = 20
+)
+
 type ProviderInfo struct {
-	ID          string `json:"id,omitempty"`
-	PublicKey   string `json:"publicKey"`
-	Addr        string `json:"address"`
-	SpaceAvail  int64  `json:"spaceAvail,omitempty"`
+	ID         string `json:"id,omitempty"`
+	PublicKey  string `json:"publicKey"`
+	Addr       string `json:"address"`
+	SpaceAvail int64  `json:"spaceAvail,omitempty"`
 	// Rate charged for storage, in tenths-of-cents/gb/month
 	// where 1 gb is 1e9 bytes
-	StorageRate int64  `json:"storageRate"`
+	StorageRate int64 `json:"storageRate"`
 	// The provider's balance, in tenths of cents.
 	Balance int64 `json:"balance"`
 }
@@ -82,6 +87,16 @@ type BlockLocation struct {
 	ContractId string `json:"contractId"`
 }
 
+// BlockAudit is a challenge used to check a block's integrity
+// when stored with an untrusted provider. It consists of a random
+// nonce and the hash expected from performing sha256(nonce + block contents).
+// To perform the audit, the nonce should be sent to the provider storing
+// the block, who must then compute the expected hash correctly.
+type BlockAudit struct {
+	Nonce        string `json:"nonce"`
+	ExpectedHash string `json:"expectedHash"`
+}
+
 type Block struct {
 	ID string `json:"id"`
 	// Offset of the block in the file, relative to the file's other blocks.
@@ -93,6 +108,8 @@ type Block struct {
 	Sha256Hash string `json:"sha256hash"`
 	// Location of the provider where the block is stored
 	Location BlockLocation `json:"location"`
+	// Audits to be used to check the block's integrity
+	Audits []BlockAudit `json:"audits"`
 }
 
 // Permission provides access to a file to a non-owning user

--- a/core/core.go
+++ b/core/core.go
@@ -110,6 +110,8 @@ type Block struct {
 	Location BlockLocation `json:"location"`
 	// Audits to be used to check the block's integrity
 	Audits []BlockAudit `json:"audits"`
+	// Whether or not the last audit passed.
+	AuditPassed bool `json:"auditPassed"`
 }
 
 // Permission provides access to a file to a non-owning user

--- a/integration/metaserver_test.go
+++ b/integration/metaserver_test.go
@@ -1,4 +1,4 @@
-package metaserver
+package integration
 
 import (
 	"bytes"

--- a/integration/provider_test.go
+++ b/integration/provider_test.go
@@ -1,0 +1,70 @@
+package integration
+
+import (
+	"testing"
+	"skybin/core"
+	"skybin/provider"
+	"net/http"
+	"skybin/renter"
+	"io/ioutil"
+	"os"
+)
+
+// This test expects that the renter and provider services are running
+// at these addresses. Additionally, no other providers should be running.
+const (
+	testProviderAddr = core.DefaultPublicProviderAddr
+	testRenterAddr = core.DefaultRenterAddr
+)
+
+func TestAudit_BadBlock(t *testing.T) {
+	pvdr := provider.NewClient(testProviderAddr, &http.Client{})
+	_, err := pvdr.AuditBlock("", "", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	_, err = pvdr.AuditBlock("askjdf", "adksjf", "alsk")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestAudit(t *testing.T) {
+	renterClient := renter.NewClient(testRenterAddr, &http.Client{})
+	_, err := renterClient.ReserveStorage(2 * 1024 * 1024 * 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tempFile, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tempFile.Close()
+	defer os.Remove(tempFile.Name())
+	f, err := renterClient.Upload(tempFile.Name(), "audit_test_file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	renterInfo, err := renterClient.GetInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pvdr := provider.NewClient(testProviderAddr, &http.Client{})
+	for _, block := range f.Versions[0].Blocks {
+		if len(block.Audits) == 0 {
+			t.Error("uploaded block has no audit info.\n" +
+				"cannot test audit without block audits enabled")
+		}
+	}
+	for _, block := range f.Versions[0].Blocks {
+		for _, audit := range block.Audits {
+			hashStr, err := pvdr.AuditBlock(renterInfo.ID, block.ID, audit.Nonce)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if hashStr != audit.ExpectedHash {
+				t.Fatal("provider performed audit incorrectly")
+			}
+		}
+	}
+}

--- a/metaserver/auditrunner.go
+++ b/metaserver/auditrunner.go
@@ -1,0 +1,111 @@
+package metaserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+// TODO: Refactor these into their own package inside of the provider.
+// Currently, we can't use them from the provider package because it causes
+// an import cycle.
+
+type postAuditParams struct {
+	Nonce string `json:"nonce"`
+}
+
+type postAuditResp struct {
+	Hash string `json:"hash"`
+}
+
+func auditBlock(addr, renterID, blockID, nonce string) (hash string, err error) {
+	client := http.Client{}
+	url := fmt.Sprintf("http://%s/blocks/audit?renterID=%s&blockID=%s", addr, renterID, blockID)
+	req := postAuditParams{nonce}
+	body, err := json.Marshal(&req)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Post(url, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", decodeError(resp.Body)
+	}
+	var respMsg postAuditResp
+	err = json.NewDecoder(resp.Body).Decode(&respMsg)
+	if err != nil {
+		return "", err
+	}
+	return respMsg.Hash, nil
+}
+
+func (server *MetaServer) startAuditRunner() {
+	// Frequency at which the runner should be triggered (should probably put this in a config file)
+	runnerFrequency := time.Minute * 1
+
+	// Ticker triggering the runner.
+	ticker := time.NewTicker(runnerFrequency)
+
+	go func() {
+		for range ticker.C {
+			server.logger.Println("Running audits...")
+			err := server.runAudits()
+			if err != nil {
+				server.logger.Println("Error when running audits:", err)
+			}
+		}
+	}()
+}
+
+func (server *MetaServer) runAudits() error {
+	// Retrieve a list of all files on the server.
+	files, err := server.db.FindAllFiles()
+	if err != nil {
+		return err
+	}
+
+	// For each file...
+	for _, file := range files {
+		server.logger.Println("Auditing blocks for file", file.ID)
+
+		// Audit each version of the file...
+		for _, version := range file.Versions {
+			server.logger.Println("Auditing version", version.Num)
+
+			// Check that each block of the stored version is still stored properly.
+			for i, block := range version.Blocks {
+				server.logger.Println("Auditing block", block.ID)
+
+				nonceToUse := rand.Intn(len(block.Audits))
+				audit := block.Audits[nonceToUse]
+				res, err := auditBlock(block.Location.Addr, file.OwnerID, block.ID, audit.Nonce)
+				if err != nil {
+					server.logger.Println("Error auditing block:", err)
+
+					version.Blocks[i].AuditPassed = false
+					continue
+				}
+				if res != audit.ExpectedHash {
+					server.logger.Println("Audit failed")
+					version.Blocks[i].AuditPassed = false
+				} else {
+					server.logger.Println("Audit passed")
+					version.Blocks[i].AuditPassed = true
+				}
+			}
+			err := server.db.UpdateFileVersion(file.ID, &version)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/metaserver/auditrunner.go
+++ b/metaserver/auditrunner.go
@@ -48,7 +48,7 @@ func auditBlock(addr, renterID, blockID, nonce string) (hash string, err error) 
 
 func (server *MetaServer) startAuditRunner() {
 	// Frequency at which the runner should be triggered (should probably put this in a config file)
-	runnerFrequency := time.Minute * 1
+	runnerFrequency := time.Minute * 5
 
 	// Ticker triggering the runner.
 	ticker := time.NewTicker(runnerFrequency)
@@ -73,30 +73,30 @@ func (server *MetaServer) runAudits() error {
 
 	// For each file...
 	for _, file := range files {
-		server.logger.Println("Auditing blocks for file", file.ID)
+		// server.logger.Println("Auditing blocks for file", file.ID)
 
 		// Audit each version of the file...
 		for _, version := range file.Versions {
-			server.logger.Println("Auditing version", version.Num)
+			// server.logger.Println("Auditing version", version.Num)
 
 			// Check that each block of the stored version is still stored properly.
 			for i, block := range version.Blocks {
-				server.logger.Println("Auditing block", block.ID)
+				// server.logger.Println("Auditing block", block.ID)
 
 				nonceToUse := rand.Intn(len(block.Audits))
 				audit := block.Audits[nonceToUse]
 				res, err := auditBlock(block.Location.Addr, file.OwnerID, block.ID, audit.Nonce)
 				if err != nil {
-					server.logger.Println("Error auditing block:", err)
+					// server.logger.Println("Error auditing block:", err)
 
 					version.Blocks[i].AuditPassed = false
 					continue
 				}
 				if res != audit.ExpectedHash {
-					server.logger.Println("Audit failed")
+					// server.logger.Println("Audit failed")
 					version.Blocks[i].AuditPassed = false
 				} else {
-					server.logger.Println("Audit passed")
+					// server.logger.Println("Audit passed")
 					version.Blocks[i].AuditPassed = true
 				}
 			}

--- a/metaserver/server.go
+++ b/metaserver/server.go
@@ -102,6 +102,7 @@ func InitServer(dataDirectory string, showDash bool, logger *log.Logger) *MetaSe
 
 	if showDash {
 		router.Handle("/dashboard.json", server.getDashboardDataHandler()).Methods("GET")
+		router.Handle("/dashboard/audit/{fileID}/{blockID}", server.getDashboardAuditHandler()).Methods("POST")
 
 		staticPath, err := getStaticPath()
 		if err != nil {

--- a/metaserver/server.go
+++ b/metaserver/server.go
@@ -112,7 +112,6 @@ func InitServer(dataDirectory string, showDash bool, logger *log.Logger) *MetaSe
 	}
 
 	server.startPaymentRunner()
-	server.startAuditRunner()
 
 	return server
 }

--- a/metaserver/server.go
+++ b/metaserver/server.go
@@ -111,6 +111,7 @@ func InitServer(dataDirectory string, showDash bool, logger *log.Logger) *MetaSe
 	}
 
 	server.startPaymentRunner()
+	server.startAuditRunner()
 
 	return server
 }

--- a/metaserver/static/dashboard.html
+++ b/metaserver/static/dashboard.html
@@ -20,6 +20,8 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.bundle.min.js"></script>
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.10/css/all.css" integrity="sha384-+d0P83n9kaQMCwj8F4RJB66tzIwOKmrdb46+porD/OvrJ+37WqIM7UoBtwHO6Nlg" crossorigin="anonymous">
+
 
     <link href="dashboard.css" rel="stylesheet" type="text/css" />
 </head>

--- a/metaserver/static/dashboard.js
+++ b/metaserver/static/dashboard.js
@@ -303,8 +303,15 @@ function showNodeInfo(nodeId) {
                 if (block.location.providerId == provider.id) {
                     blockStored = true;
                     let listItem = $('<li>');
-                    listItem.append(block.id);
-                    listItem.click(copyToClipboard);
+                    if (block.auditPassed) {
+                        listItem.append('<i title="block verified" class="fas fa-check-circle text-success"></i> ');
+                    } else {
+                        listItem.append('<i title="block corrupt" class="fas fa-times-circle text-danger"></i> ');
+                    }
+                    let idSpan = $('<span>');
+                    idSpan.append(block.id);
+                    idSpan.click(copyToClipboard);
+                    listItem.append(idSpan);
                     blockList.append(listItem);
                 }
             }

--- a/metaserver/static/dashboard.js
+++ b/metaserver/static/dashboard.js
@@ -197,6 +197,9 @@ function updateNetworkAndNodeDetails() {
     }
 }
 
+// Set of blocks that we are currently auditing.
+let auditing = {};
+
 function showNodeInfo(nodeId) {
     /** 
      * Display information about the node in the given parameters.
@@ -308,6 +311,26 @@ function showNodeInfo(nodeId) {
                     } else {
                         listItem.append('<i title="block corrupt" class="fas fa-times-circle text-danger"></i> ');
                     }
+
+                    let integrityIcon = $('<i>')
+                    integrityIcon.addClass('fas');
+                    integrityIcon.on(
+                        'click',
+                        { fileId: file.id, blockId: block.id},
+                        checkIntegrity
+                    );
+                    integrityIcon.addClass('text-primary');
+                    if (!auditing[block.id]) {
+                        integrityIcon.addClass('fa-question-circle');
+                        integrityIcon.prop('title', 'check block integrity')
+                    } else {
+                        integrityIcon.addClass('fa-spinner');
+                        integrityIcon.addClass('fa-spin');
+                        integrityIcon.prop('title', 'checking block integrity')
+                    }
+
+                    listItem.append(integrityIcon);
+
                     let idSpan = $('<span>');
                     idSpan.append(block.id);
                     idSpan.click(copyToClipboard);
@@ -328,6 +351,24 @@ function showNodeInfo(nodeId) {
         $('#provider-info').show();
         $("#file-list-container").css("max-height", $("#node-info").height()-$("#provider-info").height()-$("#general-info").height());
     }
+}
+
+function checkIntegrity(event) {
+    $(this).removeClass('fa-question-circle');
+    $(this).addClass('fa-spinner');
+    $(this).addClass('fa-spin');
+    $(this).prop('title', 'checking block integrity')
+    auditing[event.data.blockId] = true;
+
+    var xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+            delete auditing[event.data.blockId];
+        }
+    }
+    // Get data from metaserver.
+    xhttp.open("POST", "/dashboard/audit/" + event.data.fileId + "/" + event.data.blockId, true)
+    xhttp.send()
 }
 
 function updateNodeInfo() {

--- a/renter/config.go
+++ b/renter/config.go
@@ -12,6 +12,8 @@ type Config struct {
 	DefaultDataBlocks           int    `json:"defaultDataBlocks"`
 	DefaultParityBlocks         int    `json:"defaultParityBlocks"`
 	DefaultContractDurationDays int    `json:"defaultContractDurationDays"`
+	// Block audits to create per block
+	NumBlockAudits              int    `json:"numBlockAudits"`
 }
 
 const (
@@ -35,6 +37,9 @@ const (
 
 	// Default contract duration - 6 months
 	kDefaultContractDurationDays = 30 * 6
+
+	// Number of block audits to generate for each uploaded block
+	kDefaultBlockAudits = 2
 )
 
 func DefaultConfig() *Config {
@@ -44,5 +49,6 @@ func DefaultConfig() *Config {
 		DefaultDataBlocks:           kDefaultDataBlocks,
 		DefaultParityBlocks:         kDefaultParityBlocks,
 		DefaultContractDurationDays: kDefaultContractDurationDays,
+		NumBlockAudits:              kDefaultBlockAudits,
 	}
 }

--- a/renter/upload.go
+++ b/renter/upload.go
@@ -825,6 +825,7 @@ func prepareMetadata(up *fileUpload, numAudits int) error {
 			Size:       n,
 			Sha256Hash: blockHashStr,
 			Audits:     audits,
+			AuditPassed: true,
 		}
 		blocks = append(blocks, block)
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/satori/go.uuid"
+	"skybin/core"
+	"crypto/rand"
 )
 
 func SaveJson(filename string, v interface{}) error {
@@ -42,6 +44,15 @@ func GenerateID() (string, error) {
 		return "", err
 	}
 	return id.String(), nil
+}
+
+func GenerateAuditNonce() ([]byte, error) {
+	buf := make([]byte, core.DefaultAuditNonceLen)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
 }
 
 func MarshalPrivateKey(key *rsa.PrivateKey) []byte {


### PR DESCRIPTION
Adds auditing capabilities to the metaserver and provider.

Each block now has a new field, `auditPassed`, that shows whether or not the audit was successfully verified by the metaserver.

The metaserver audits each block once every 5 minutes (for now).

The metaserver dashboard shows whether or not each block has been successfully verified, and lets the user trigger an audit for a specific block by clicking on a question mark button.